### PR TITLE
Add motorcycle emoji to activity icon options

### DIFF
--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -258,6 +258,7 @@ export const ca = {
     ski: 'Esquí',
     snowboard: 'Snowboard',
     car: 'Cotxe',
+    motorcycle: 'Motocicleta',
     plane: 'Avió',
     train: 'Tren',
   },

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -258,6 +258,7 @@ export const en = {
     ski: 'Ski',
     snowboard: 'Snowboard',
     car: 'Car',
+    motorcycle: 'Motorcycle',
     plane: 'Plane',
     train: 'Train',
   },

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -258,6 +258,7 @@ export const es = {
     ski: 'Esquí',
     snowboard: 'Snowboard',
     car: 'Coche',
+    motorcycle: 'Motocicleta',
     plane: 'Avión',
     train: 'Tren',
   },

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -258,6 +258,7 @@ export const fr = {
     ski: 'Ski',
     snowboard: 'Snowboard',
     car: 'Voiture',
+    motorcycle: 'Moto',
     plane: 'Avion',
     train: 'Train',
   },

--- a/app/src/utils/activityIcons.ts
+++ b/app/src/utils/activityIcons.ts
@@ -39,6 +39,7 @@ export const ACTIVITY_ICONS: ActivityIconOption[] = [
   { value: '🛹', labelKey: 'activities.skate', kind: 'emoji', content: '🛹' },
   { value: '🎿', labelKey: 'activities.ski', kind: 'emoji', content: '🎿' },
   { value: '🏂', labelKey: 'activities.snowboard', kind: 'emoji', content: '🏂' },
+  { value: '🏍️', labelKey: 'activities.motorcycle', kind: 'emoji', content: '🏍️' },
   { value: '🚗', labelKey: 'activities.car', kind: 'emoji', content: '🚗' },
   { value: '✈️', labelKey: 'activities.plane', kind: 'emoji', content: '✈️' },
   { value: '🚂', labelKey: 'activities.train', kind: 'emoji', content: '🚂' },


### PR DESCRIPTION
Adds the motorcycle emoji 🏍️ as a selectable activity icon.

## Changes
- `activityIcons.ts`: new `🏍️` emoji option alongside the other vehicle icons (before the car).
- Localized labels added in all four locales: en `Motorcycle`, es/ca `Motocicleta`, fr `Moto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)