### PR TITLE
Fix white/missing map tiles at replay start (#63)

### DIFF
--- a/PRELOAD_TILES_PLAN.md
+++ b/PRELOAD_TILES_PLAN.md
@@ -1,0 +1,207 @@
+# Plan — Fix white/missing map tiles at replay start (Issue #63)
+
+> **Scope of this document: Option A only** — gate the cinematic intro on map tile
+> readiness using MapLibre's `idle` event, via a new `preloading` animation phase.
+> Corridor prefetch (Option B) is intentionally out of scope here and can be layered
+> on later inside the same phase.
+
+## 1. Problem
+
+GitHub issue #63 ("3D missing map tiles, pre-load"): after a GPX is uploaded, the
+satellite/terrain tiles for the playback viewport are not loaded yet. When the user
+presses play, the camera immediately flies from the flat overview (zoom ≤ 12,
+pitch 0) to the follow-behind start position (zoom ~14–15, pitch ~60°). Tiles at
+those zoom levels — both ESRI satellite and the AWS `terrain-dem` (terrarium)
+raster-DEM — have not been fetched, so they render as **white squares** during the
+2 s intro and the first moments of playback. Reference apps (Relive,
+pelmers.com/gpx-replay) avoid this by **loading the scene before animating**.
+
+The web app (`trailreplay/app`, MapLibre GL) is the surface to fix. The iOS app
+embeds this same web bundle via `WebMapRuntime`, so a web fix covers both.
+
+## 2. Root cause (code references)
+
+- `app/src/components/playback/PlaybackProvider.tsx:73-86` — on play, immediately
+  sets `animationPhase = 'intro'` and starts a 2 s timer to `'playing'`. No wait for
+  tiles.
+- `app/src/components/map/hooks/useTrailPlaybackCamera.ts:209-221` — the `intro`
+  branch runs `easeTo`/`flyTo` to the high-zoom, high-pitch start as soon as the
+  phase is `intro`.
+- `app/src/components/map/mapStyle.ts:17-67` — satellite (`background`) and
+  `terrain-dem` are network raster sources with no local cache priming.
+- The overview fit (`useTrailLayerData.ts:163-188`) only loads tiles at `maxZoom:
+  12`, flat — a different tile set than playback needs.
+
+## 3. Approach (Option A)
+
+Insert a **`preloading`** phase between the play press and the intro:
+
+1. User presses play (or export calls `play()`).
+2. `PlaybackProvider` sees this is a fresh cinematic start
+   (`!cinematicPlayed && progress < 0.01`) and sets `animationPhase = 'preloading'`
+   instead of `'intro'`.
+3. A new hook (`useTilePreload`) reacts to the `preloading` phase:
+   - `jumpTo` (instant, no easing) the **intro's final camera target** — the same
+     center/zoom/pitch/bearing the intro `flyTo` would end at. This forces MapLibre
+     to request exactly the tiles playback will start with.
+   - Listen with `map.once('idle', …)`. MapLibre fires `idle` when all tiles for the
+     current view are loaded and the map is fully rendered.
+   - When `idle` fires (or a safety timeout elapses), `jumpTo` **back** to the
+     overview position the intro starts from, then advance
+     `animationPhase = 'intro'`.
+4. The existing intro logic in `useTrailPlaybackCamera.ts` runs unchanged — it just
+   fires a beat later, now against a warm tile cache. No white tiles.
+
+A lightweight "Preparing replay…" overlay is shown while in `preloading`.
+
+### Why `jumpTo` to the target, then back
+
+`idle` only guarantees tiles for the *current* viewport. The viewport that matters
+is where playback **starts** (high zoom + pitch), not the overview. So we briefly
+jump the (invisible-to-user, covered by overlay) camera to the start target to prime
+those exact tiles, then snap back so the intro `flyTo` animation still plays from the
+overview for the cinematic effect.
+
+> Alternative considered: skip the round-trip and just start the intro from the
+> target. Rejected — it removes the cinematic zoom-in that the intro is designed to
+> provide.
+
+## 4. Changes (file by file)
+
+### 4.1 Store: add the phase to the type union
+
+The phase union appears in **three** places — all must be updated together:
+
+- `app/src/store/storeTypes.ts:35` — `animationPhase` field type.
+- `app/src/store/storeTypes.ts:95` — `setAnimationPhase` parameter type.
+- `app/src/store/slices/playbackSlice.ts` — the slice `Pick` carries the type from
+  `AppState`, so no literal there, but verify `resetPlayback` still resets to
+  `'idle'` (it does, line 91).
+
+Change each union from:
+```ts
+'idle' | 'intro' | 'playing' | 'outro' | 'ended'
+```
+to:
+```ts
+'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended'
+```
+
+> Grep `'idle' | 'intro'` and `animationPhase ===` across `app/src` to confirm no
+> other exhaustive switch needs a new case. Known consumers:
+> `useVideoExportRecorder.ts:581-594` (only checks playing/intro/outro/ended — safe,
+> `preloading` is a no-op there), `PlaybackControls.tsx:581-595`,
+> `MapElevationProfile.tsx`. None break on an unhandled extra value; they all use
+> `if`-chains, not exhaustive switches.
+
+### 4.2 `PlaybackProvider.tsx` — route play through `preloading`
+
+In the "handle play start" effect (lines 73-86):
+
+- When `playback.isPlaying && !cinematicPlayed && playback.progress < 0.01`:
+  set `animationPhase = 'preloading'` (was `'intro'`). **Do not** start the
+  `INTRO_DURATION` timer here anymore — the transition to `'intro'` now comes from
+  the preload hook.
+- Keep the `else if (cinematicPlayed && animationPhase === 'idle')` branch
+  (resume → straight to `'playing'`). A resume mid-track should not re-preload.
+- Add a new effect: when `animationPhase === 'intro'` begins, start the existing
+  `INTRO_DURATION` timer that flips to `'playing'` + `setCinematicPlayed(true)`.
+  (Move the timer out of the play-start effect so it fires after preloading, not
+  before.)
+
+Net: `idle → preloading → intro → playing` for a cold start;
+`idle → playing` for a warm resume.
+
+### 4.3 New hook `app/src/components/map/hooks/useTilePreload.ts`
+
+Responsibilities:
+- Inputs: `mapRef`, `isMapLoaded`, `animationPhase`, `allCoordinates`,
+  `cameraMode`, `followBehindZoomLevel`, `elevationData`, `setAnimationPhase`,
+  and the bearing refs (`smoothBearingRef`, `targetBearingRef`).
+- Runs only when `animationPhase === 'preloading'`.
+- Computes the intro **target** camera the same way
+  `useTrailPlaybackCamera.ts:292-330` computes the intro start (start point,
+  look-ahead bearing, terrain-aware zoom/pitch via
+  `getFollowBehindCameraTarget` + `calculateTerrainAwareAdjustments`). Reuse those
+  helpers to stay consistent.
+- Sequence:
+  1. Capture the current overview camera (`map.getCenter/Zoom/Pitch/Bearing`) so we
+     can restore it.
+  2. `map.jumpTo(target)` — primes start tiles.
+  3. `const done = () => { map.jumpTo(overview); setAnimationPhase('intro'); }`
+  4. `map.once('idle', done)` **and** a safety
+     `setTimeout(done, PRELOAD_TIMEOUT_MS)` (e.g. 6000 ms) so a slow/offline tile
+     server can never wedge the UI. Guard with a `hasAdvancedRef` so whichever
+     fires first wins and the other is a no-op; clear the timeout / `map.off` in
+     cleanup.
+- For `cameraMode === 'overview'`: there is no high-zoom flythrough, so preloading
+  the start target is unnecessary. Short-circuit: advance straight to `'intro'`
+  (which for overview is already handled benignly), or skip the jump round-trip.
+  Keep the overlay flash minimal here.
+
+Wire the hook into `TrailMap.tsx` alongside the other hooks (after
+`useTrailPlaybackCamera`, sharing the same refs).
+
+### 4.4 Loading overlay during `preloading`
+
+Add a small centered overlay in `TrailMap.tsx` (mirror the existing
+`!isMapLoaded` spinner block at lines 294-301), shown when
+`animationPhase === 'preloading'`:
+- Spinner + `t('map.preparingReplay')` (new i18n key).
+- Non-blocking visually; sits above the canvas so the brief `jumpTo` round-trip
+  isn't visible to the user.
+
+Add the `map.preparingReplay` string to every locale file under
+`app/src/i18n/locales/` (en, es, ca — and any others present).
+
+## 5. Export path consideration
+
+`useVideoExportRecorder.ts` calls `play()` at line 786 after `startFrameCapture()`.
+With preloading in place, the recorder would capture the `preloading` frames (a
+static start frame under the overlay) before the intro. Two options — pick one in
+implementation:
+
+- **(Preferred) Let it preload too.** Benefit: exported video also has no white
+  tiles. Cost: a few static frames at the very start. Mitigate by **not rendering
+  the overlay during export** (check `isExporting`) and keeping the preload jump
+  round-trip — the recorded frames will just show the warm start position briefly.
+- **Skip preloading during export.** If export already does its own warmup, gate the
+  `preloading` branch in `PlaybackProvider` on `!isExporting`. Simpler but leaves
+  exports potentially showing white tiles.
+
+Recommend the first; verify recorded output starts clean.
+
+## 6. Edge cases
+
+- **Pause during preloading**: if `isPlaying` flips to false while `preloading`,
+  cancel: `map.off('idle')`, clear timeout, restore overview camera, set phase back
+  to `'idle'`. Handle in the hook's effect cleanup keyed on `isPlaying`.
+- **GPX changed / unmount mid-preload**: hook cleanup must `off` the listener and
+  clear the timeout (already covered by effect cleanup).
+- **`idle` never fires** (tiles error / offline): safety timeout guarantees
+  progress. Acceptable to show some white tiles in the truly-offline case — no worse
+  than today.
+- **Resume after first play**: `cinematicPlayed` is true → bypass preloading
+  entirely (matches current resume behavior).
+- **Map not loaded yet**: hook is gated on `isMapLoaded`; if play is pressed before
+  load (shouldn't happen — controls appear after load), the effect waits.
+
+## 7. Test / verification
+
+- Manual: load a GPX in a region with high-zoom imagery, hard-refresh to clear
+  cache, press play. Expect a brief "Preparing replay…" then a clean intro with no
+  white tiles. Repeat with throttled network (DevTools "Slow 3G") to confirm the
+  overlay holds until tiles arrive and the safety timeout still releases.
+- Regression: overview camera mode still works; pause/resume still skips preload;
+  outro/reset unaffected; export produces a clean opening.
+- Type-check: `npm run build` / `tsc` passes with the widened union (no missing
+  switch cases).
+- Existing unit tests under `app/src/**/*.test.ts` unaffected (none assert on the
+  phase union literally — verify with a grep before finishing).
+
+## 8. Out of scope (future, Option B)
+
+Inside the `preloading` phase, additionally `fetch()` the satellite + `terrain-dem`
+tiles for ~15–20 sampled points along the whole route (z14/z15 + neighbors) to warm
+the browser HTTP cache for the **rest** of the flythrough, not just the start. Not
+included in this plan.

--- a/app/src/components/map/TrailMap.tsx
+++ b/app/src/components/map/TrailMap.tsx
@@ -20,6 +20,7 @@ import { useBaseMapPresentation } from './hooks/useBaseMapPresentation';
 import { useMapInitialization } from './hooks/useMapInitialization';
 import { useTrailLayerData } from './hooks/useTrailLayerData';
 import { useTrailPlaybackCamera } from './hooks/useTrailPlaybackCamera';
+import { useTilePreload } from './hooks/useTilePreload';
 import { projectCoordinateToJourney, projectCoordinateToTrack } from '@/utils/routeProjection';
 import type { CropPreviewMetrics } from '@/utils/crop';
 
@@ -56,6 +57,8 @@ export function TrailMap(_props: TrailMapProps) {
   const pendingPicturePlacements = useAppStore((state) => state.pendingPicturePlacements);
   const playback = useAppStore((state) => state.playback);
   const animationPhase = useAppStore((state) => state.animationPhase);
+  const isExporting = useAppStore((state) => state.isExporting);
+  const setAnimationPhase = useAppStore((state) => state.setAnimationPhase);
   const setCameraPosition = useAppStore((state) => state.setCameraPosition);
   const setCameraSettings = useAppStore((state) => state.setCameraSettings);
   const setSelectedPictureId = useAppStore((state) => state.setSelectedPictureId);
@@ -215,6 +218,19 @@ export function TrailMap(_props: TrailMapProps) {
     },
   });
 
+  useTilePreload({
+    allCoordinates,
+    animationPhase,
+    elevationData,
+    followBehindZoomLevel,
+    isMapLoaded,
+    isPlaying: playback.isPlaying,
+    mapRef: map,
+    setAnimationPhase,
+    smoothBearingRef,
+    targetBearingRef,
+  });
+
   useEffect(() => {
     if (!map.current || !isMapLoaded) return;
 
@@ -296,6 +312,15 @@ export function TrailMap(_props: TrailMapProps) {
           <div className="flex items-center gap-3">
             <div className="w-6 h-6 border-2 border-[var(--trail-orange)] border-t-transparent rounded-full animate-spin" />
             <span className="text-[var(--evergreen)]">{t('map.loading')}</span>
+          </div>
+        </div>
+      )}
+
+      {animationPhase === 'preloading' && !isExporting && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[rgba(9,14,19,0.55)] backdrop-blur-[1px]">
+          <div className="flex items-center gap-3 rounded-2xl border border-white/12 bg-[rgba(9,14,19,0.88)] px-4 py-3 text-white shadow-[0_16px_36px_rgba(0,0,0,0.28)]">
+            <div className="w-6 h-6 border-2 border-[var(--trail-orange)] border-t-transparent rounded-full animate-spin" />
+            <span>{t('map.preparingReplay')}</span>
           </div>
         </div>
       )}

--- a/app/src/components/map/hooks/useMapInitialization.ts
+++ b/app/src/components/map/hooks/useMapInitialization.ts
@@ -36,6 +36,10 @@ export function useMapInitialization({
       maxPitch: 85,
       preserveDrawingBuffer: true,
       attributionControl: false,
+      // Keep more tiles in memory than the viewport-based default so the tiles
+      // warmed during the `preloading` phase (and along the route) aren't evicted
+      // mid-flythrough, which would re-introduce white tiles. See issue #63.
+      maxTileCacheSize: 1000,
     } as ConstructorParameters<typeof maplibregl.Map>[0]);
 
     mapGlobalRef.current = mapRef.current;

--- a/app/src/components/map/hooks/useTilePreload.ts
+++ b/app/src/components/map/hooks/useTilePreload.ts
@@ -1,0 +1,167 @@
+import { useEffect, useRef } from 'react';
+import type maplibregl from 'maplibre-gl';
+import { getFollowBehindCameraTarget } from '@/utils/followBehindCamera';
+import {
+  calculateTerrainAwareAdjustments,
+  TERRAIN_CAMERA_SETTINGS,
+} from '@/components/map/cameraUtils';
+
+// Safety net so a slow or offline tile server can never wedge the UI in the
+// preloading phase. If `idle` hasn't fired by now, advance to the intro anyway.
+const PRELOAD_TIMEOUT_MS = 6000;
+
+type AnimationPhase = 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended';
+
+interface UseTilePreloadParams {
+  allCoordinates: number[][];
+  animationPhase: AnimationPhase;
+  elevationData: Array<{ elevation: number; progress?: number }>;
+  followBehindZoomLevel: number;
+  isMapLoaded: boolean;
+  isPlaying: boolean;
+  mapRef: React.MutableRefObject<maplibregl.Map | null>;
+  setAnimationPhase: (phase: AnimationPhase) => void;
+  smoothBearingRef: React.MutableRefObject<number>;
+  targetBearingRef: React.MutableRefObject<number>;
+}
+
+/**
+ * While `animationPhase === 'preloading'`, instantly jump the (overlay-covered)
+ * camera to the intro's final target so MapLibre fetches exactly the tiles the
+ * cinematic intro and playback will start with. Once those tiles are loaded
+ * (`map.once('idle')`) — or a safety timeout elapses — snap the camera back to
+ * the overview and advance to the `intro` phase. The intro flyTo then animates
+ * from the overview against a warm tile cache, so no white tiles appear.
+ *
+ * Fixes issue #63 (3D missing map tiles, pre-load).
+ */
+export function useTilePreload({
+  allCoordinates,
+  animationPhase,
+  elevationData,
+  followBehindZoomLevel,
+  isMapLoaded,
+  isPlaying,
+  mapRef,
+  setAnimationPhase,
+  smoothBearingRef,
+  targetBearingRef,
+}: UseTilePreloadParams) {
+  const hasAdvancedRef = useRef(false);
+
+  useEffect(() => {
+    if (animationPhase !== 'preloading') {
+      hasAdvancedRef.current = false;
+      return;
+    }
+
+    // Paused while preloading: abort and return to idle (cleanup of the prior
+    // run restores the overview camera).
+    if (!isPlaying) {
+      setAnimationPhase('idle');
+      return;
+    }
+
+    const map = mapRef.current;
+    if (!map || !isMapLoaded || allCoordinates.length === 0) {
+      // Nothing to warm up — go straight to the intro.
+      setAnimationPhase('intro');
+      return;
+    }
+
+    hasAdvancedRef.current = false;
+
+    // Compute the intro's final camera target the same way useTrailPlaybackCamera
+    // does, so we prime the exact tiles the intro flyTo lands on.
+    const preset = getFollowBehindCameraTarget(followBehindZoomLevel, 'intro');
+    const startPoint = allCoordinates[0];
+    const lookAheadPoint = allCoordinates[Math.min(10, allCoordinates.length - 1)];
+
+    if (!startPoint || !lookAheadPoint) {
+      setAnimationPhase('intro');
+      return;
+    }
+
+    const lat1 = (startPoint[1] * Math.PI) / 180;
+    const lat2 = (lookAheadPoint[1] * Math.PI) / 180;
+    const lon1 = (startPoint[0] * Math.PI) / 180;
+    const lon2 = (lookAheadPoint[0] * Math.PI) / 180;
+    const y = Math.sin(lon2 - lon1) * Math.cos(lat2);
+    const x =
+      Math.cos(lat1) * Math.sin(lat2) -
+      Math.sin(lat1) * Math.cos(lat2) * Math.cos(lon2 - lon1);
+    const initialBearing = ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+
+    const startElevation = elevationData.length > 0 ? elevationData[0].elevation : 0;
+    const { zoomAdjust, pitchAdjust } = calculateTerrainAwareAdjustments(startElevation, elevationData, 0);
+
+    const targetZoom = Math.max(
+      TERRAIN_CAMERA_SETTINGS.MIN_ZOOM,
+      Math.min(TERRAIN_CAMERA_SETTINGS.MAX_ZOOM, preset.zoom - zoomAdjust)
+    );
+    const targetPitch = Math.max(
+      TERRAIN_CAMERA_SETTINGS.MIN_PITCH,
+      Math.min(TERRAIN_CAMERA_SETTINGS.MAX_PITCH, preset.pitch - pitchAdjust)
+    );
+
+    // Remember the overview the intro animates from, so we can restore it.
+    const overview = {
+      center: map.getCenter(),
+      zoom: map.getZoom(),
+      pitch: map.getPitch(),
+      bearing: map.getBearing(),
+    };
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const advance = () => {
+      if (hasAdvancedRef.current) return;
+      hasAdvancedRef.current = true;
+      map.off('idle', advance);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      // Snap back to the overview so the intro flyTo still plays the cinematic
+      // zoom-in — now against warm tiles.
+      map.jumpTo(overview);
+      smoothBearingRef.current = initialBearing;
+      targetBearingRef.current = initialBearing;
+      setAnimationPhase('intro');
+    };
+
+    // Prime the start tiles, then wait for them to finish loading.
+    map.jumpTo({
+      center: startPoint as [number, number],
+      zoom: targetZoom,
+      pitch: targetPitch,
+      bearing: initialBearing,
+    });
+    map.once('idle', advance);
+    timeoutId = setTimeout(advance, PRELOAD_TIMEOUT_MS);
+
+    return () => {
+      map.off('idle', advance);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      // If we leave preloading without having advanced (e.g. pause/unmount),
+      // restore the overview camera so we don't leave the map at the primed target.
+      if (!hasAdvancedRef.current) {
+        map.jumpTo(overview);
+      }
+    };
+  }, [
+    allCoordinates,
+    animationPhase,
+    elevationData,
+    followBehindZoomLevel,
+    isMapLoaded,
+    isPlaying,
+    mapRef,
+    setAnimationPhase,
+    smoothBearingRef,
+    targetBearingRef,
+  ]);
+}

--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -16,7 +16,7 @@ import {
 interface UseTrailPlaybackCameraParams {
   activeTrack: { points: Array<{ heartRate: number | null }> } | null | undefined;
   allCoordinates: number[][];
-  animationPhase: 'idle' | 'intro' | 'playing' | 'outro' | 'ended';
+  animationPhase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended';
   cameraMode: 'overview' | 'follow' | 'follow-behind';
   completedCoordinates: number[][];
   computedJourney: { coordinates: Array<{ heartRate: number | null }> } | null;

--- a/app/src/components/map/mapStyle.ts
+++ b/app/src/components/map/mapStyle.ts
@@ -67,6 +67,11 @@ export const MAP_STYLE = {
     },
   },
   layers: [
+    // Neutral base fill underneath every raster basemap. When a tile hasn't
+    // loaded yet (cold start, slow network, or the preload safety timeout firing
+    // offline), the gap shows this muted color instead of glaring white. See
+    // issue #63.
+    { id: 'base-fill', type: 'background', paint: { 'background-color': '#141b22' } },
     { id: 'background', type: 'raster', source: 'satellite' },
     { id: 'esri-clarity', type: 'raster', source: 'esri-clarity', layout: { visibility: 'none' } },
     { id: 'carto-labels', type: 'raster', source: 'carto-labels', layout: { visibility: 'none' } },

--- a/app/src/components/playback/PlaybackProvider.tsx
+++ b/app/src/components/playback/PlaybackProvider.tsx
@@ -69,21 +69,41 @@ export function PlaybackProvider({ children }: PlaybackProviderProps) {
     }
   }, []);
 
-  // Handle play start - trigger intro animation if not played yet
+  // Handle play start - trigger tile preloading before the intro animation.
+  // The map tiles for the high-zoom/pitched playback start aren't loaded yet on a
+  // fresh play, so we insert a `preloading` phase (see useTilePreload) that warms
+  // those tiles via the MapLibre `idle` event before the cinematic intro runs.
   useEffect(() => {
     if (playback.isPlaying && !cinematicPlayed && playback.progress < 0.01) {
-      // Start intro animation
-      setAnimationPhase('intro');
-
-      // After intro, start actual playback
-      introTimeoutRef.current = setTimeout(() => {
-        setCinematicPlayed(true);
-        setAnimationPhase('playing');
-      }, INTRO_DURATION);
+      // Cold cinematic start: preload tiles first. The preload hook advances the
+      // phase to 'intro' once tiles are ready (or a safety timeout elapses).
+      if (animationPhase === 'idle') {
+        setAnimationPhase('preloading');
+      }
     } else if (playback.isPlaying && cinematicPlayed && animationPhase === 'idle') {
+      // Warm resume mid-track: skip preload and intro entirely.
       setAnimationPhase('playing');
     }
-  }, [playback.isPlaying, cinematicPlayed, playback.progress, animationPhase, setCinematicPlayed, setAnimationPhase]);
+  }, [playback.isPlaying, cinematicPlayed, playback.progress, animationPhase, setAnimationPhase]);
+
+  // Once preloading completes and we enter the intro phase, run the cinematic
+  // intro timer. This fires after the warm-up rather than before it, so the intro
+  // flyTo animates against an already-loaded tile cache (no white squares).
+  useEffect(() => {
+    if (animationPhase !== 'intro') return;
+
+    introTimeoutRef.current = setTimeout(() => {
+      setCinematicPlayed(true);
+      setAnimationPhase('playing');
+    }, INTRO_DURATION);
+
+    return () => {
+      if (introTimeoutRef.current) {
+        clearTimeout(introTimeoutRef.current);
+        introTimeoutRef.current = null;
+      }
+    };
+  }, [animationPhase, setCinematicPlayed, setAnimationPhase]);
 
   // Animation loop - only run when in 'playing' phase
   useEffect(() => {

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -602,6 +602,7 @@ export const ca = {
   },
   map: {
     loading: 'Carregant mapa...',
+    preparingReplay: 'Preparant la reproducció…',
     zoomButtonsHint: 'Fes servir els botons + i - per canviar el nivell de zoom mentre es reprodueix l’animació.',
   },
   errors: {

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -602,6 +602,7 @@ export const en = {
   },
   map: {
     loading: 'Loading map...',
+    preparingReplay: 'Preparing replay…',
     zoomButtonsHint: 'Use the + and - buttons to change the zoom while the animation plays.',
   },
   errors: {

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -602,6 +602,7 @@ export const es = {
   },
   map: {
     loading: 'Cargando mapa...',
+    preparingReplay: 'Preparando la repetición…',
     zoomButtonsHint: 'Usa los botones + y - para cambiar el nivel de zoom mientras se reproduce la animación.',
   },
   errors: {

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -602,6 +602,7 @@ help: {
   },
   map: {
     loading: 'Chargement de la carte...',
+    preparingReplay: 'Préparation de la rediffusion…',
     zoomButtonsHint: 'Utilisez les boutons + et - pour modifier le zoom pendant l\'animation.',
   },
   errors: {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -136,7 +136,12 @@ html, body {
   justify-content: center;
   z-index: 100;
   position: relative;
-  transition: transform 0.2s ease;
+  /* No transition on `transform`: MapLibre writes the marker's projected
+     screen position onto this element's `transform` on every render. A
+     transition would ease each update over 0.2s, so the marker lags behind
+     its true position — drifting off the trail tip and rubber-banding during
+     camera pans (and baking that offset into video exports, which sample this
+     element's rect). The position is already smooth via per-frame interpolation. */
 }
 
 /* Pulse animation for marker glow circle */

--- a/app/src/store/storeTypes.ts
+++ b/app/src/store/storeTypes.ts
@@ -32,7 +32,7 @@ export interface AppState {
   textAnnotations: TextAnnotation[];
   playback: PlaybackState;
   cinematicPlayed: boolean;
-  animationPhase: 'idle' | 'intro' | 'playing' | 'outro' | 'ended';
+  animationPhase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended';
   settings: AppSettings;
   cameraSettings: CameraSettings;
   videoExportSettings: VideoExportSettings;
@@ -92,7 +92,7 @@ export interface AppState {
   setRouteTimingMode: (mode: PlaybackState['routeTimingMode']) => void;
   setCurrentSegment: (index: number, progress: number) => void;
   setCinematicPlayed: (played: boolean) => void;
-  setAnimationPhase: (phase: 'idle' | 'intro' | 'playing' | 'outro' | 'ended') => void;
+  setAnimationPhase: (phase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended') => void;
   resetPlayback: () => void;
   setSettings: (settings: Partial<AppSettings>) => void;
   setCameraSettings: (settings: Partial<CameraSettings>) => void;


### PR DESCRIPTION
Insert a `preloading` animation phase between the play press and the cinematic intro. A new useTilePreload hook jumpTo's the intro's final camera target to prime exactly the tiles playback starts with, waits for MapLibre's `idle` event (with a 6s safety timeout), then snaps back to the overview and advances to `intro` — so the intro flyTo animates against a warm tile cache with no white squares.

- store: add `preloading` to the animationPhase union
- PlaybackProvider: route cold starts through `preloading`; move the intro timer to fire when the intro phase begins (after warm-up)
- useTilePreload: prime start tiles, gate on `idle`, restore overview; handles pause-during-preload and unmount
- TrailMap: "Preparing replay…" overlay (hidden during export so exports preload too and record clean)
- i18n: add map.preparingReplay (en, es, ca, fr)

Hardening to reduce white tiles beyond the start:
- mapStyle: neutral base-fill layer under the basemap so unloaded tiles show a muted color instead of glaring white
- map init: raise maxTileCacheSize so warmed tiles survive the flythrough