### PR TITLE
Improve replay camera and export timing

### DIFF
--- a/app/src/components/map/MapElevationProfile.tsx
+++ b/app/src/components/map/MapElevationProfile.tsx
@@ -18,7 +18,6 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
   const isExporting = useAppStore((state) => state.isExporting);
   const activePanel = useAppStore((state) => state.activePanel);
   const videoExportSettings = useAppStore((state) => state.videoExportSettings);
-  const exportSubMode = useAppStore((state) => state.exportSubMode);
   const exportAspectRatio = videoExportSettings.aspectRatio;
 
   // Use computed journey for multi-track support
@@ -181,15 +180,9 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
     return { pathD, currentElevation, markerX: progressX, markerY, currentColor };
   }, [profileData, playback.progress, currentTrackColor, trailStyle.trailColor, isInTransport]);
 
-  // Keep a capture-only profile mounted for video exports that explicitly
-  // include elevation, even if the on-map preference is disabled.
-  const shouldShowForVideoExport = videoExportSettings.includeElevation &&
-    exportSubMode === 'video' &&
-    (isExporting || activePanel === 'export');
-
-  // Don't show during intro/outro animations unless it is needed for export.
+  // The Style setting is the single source of truth for both preview and export.
   const shouldShow = profileData &&
-    (settings.showElevationProfile || shouldShowForVideoExport) &&
+    settings.showElevationProfile &&
     (animationPhase === 'idle' || animationPhase === 'playing');
 
   if (!shouldShow) {

--- a/app/src/components/map/TrailMap.tsx
+++ b/app/src/components/map/TrailMap.tsx
@@ -84,7 +84,6 @@ export function TrailMap(_props: TrailMapProps) {
   // Use the computed journey hook for multi-track support
   const {
     currentPosition,
-    currentBearing,
     currentIcon,
     currentSegment,
     completedCoordinates,
@@ -195,7 +194,6 @@ export function TrailMap(_props: TrailMapProps) {
     cameraMode,
     completedCoordinates,
     computedJourney,
-    currentBearing,
     currentIcon,
     currentPosition,
     currentSegment,

--- a/app/src/components/map/TrailMap.tsx
+++ b/app/src/components/map/TrailMap.tsx
@@ -49,6 +49,7 @@ export function TrailMap(_props: TrailMapProps) {
   const smoothBearingRef = useRef<number>(0);
   const targetBearingRef = useRef<number>(0);
   const loadZoomDoneRef = useRef<boolean>(false);
+  const handledZoomButtonPressRef = useRef(false);
 
   const tracks = useAppStore((state) => state.tracks);
   const settings = useAppStore((state) => state.settings);
@@ -273,16 +274,18 @@ export function TrailMap(_props: TrailMapProps) {
       return;
     }
 
-    const interceptZoomButton = (event: Event, direction: 1 | -1) => {
+    const changeFollowBehindDistance = (event: Event, direction: 1 | -1) => {
       const isAnimating = animationPhase === 'intro' || animationPhase === 'playing';
-      if (cameraMode !== 'follow-behind' || !isAnimating) return;
+      if (cameraMode !== 'follow-behind' || !isAnimating) return false;
 
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation?.();
 
-      const currentZoom = map.current?.getZoom()
-        ?? getFollowBehindCameraTarget(followBehindZoomLevel, 'playback').zoom;
+      // Use the saved distance preset, not the map's live zoom. Terrain safety
+      // can temporarily zoom the camera out, and deriving from that value made
+      // a button press appear to do nothing or jump to the wrong distance.
+      const currentZoom = getFollowBehindCameraTarget(followBehindZoomLevel, 'playback').zoom;
       const nextLevel = getFollowBehindZoomLevelFromZoom(
         currentZoom + (direction * ZOOM_BUTTON_STEP),
         'playback',
@@ -292,15 +295,40 @@ export function TrailMap(_props: TrailMapProps) {
         followBehindPreset: getNearestFollowBehindPreset(nextLevel),
         followBehindZoomLevel: nextLevel,
       });
+      return true;
     };
 
-    const handleZoomInClick = (event: Event) => interceptZoomButton(event, 1);
-    const handleZoomOutClick = (event: Event) => interceptZoomButton(event, -1);
+    const handleZoomButtonPress = (event: Event, direction: 1 | -1) => {
+      handledZoomButtonPressRef.current = changeFollowBehindDistance(event, direction);
+    };
+    const handleZoomButtonClick = (event: Event, direction: 1 | -1) => {
+      if (handledZoomButtonPressRef.current) {
+        handledZoomButtonPressRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation?.();
+        return;
+      }
+      changeFollowBehindDistance(event, direction);
+    };
 
+    const handleZoomInPress = (event: Event) => handleZoomButtonPress(event, 1);
+    const handleZoomOutPress = (event: Event) => handleZoomButtonPress(event, -1);
+    const handleZoomInClick = (event: Event) => handleZoomButtonClick(event, 1);
+    const handleZoomOutClick = (event: Event) => handleZoomButtonClick(event, -1);
+
+    zoomInButton.addEventListener('mousedown', handleZoomInPress, true);
+    zoomOutButton.addEventListener('mousedown', handleZoomOutPress, true);
+    zoomInButton.addEventListener('touchstart', handleZoomInPress, true);
+    zoomOutButton.addEventListener('touchstart', handleZoomOutPress, true);
     zoomInButton.addEventListener('click', handleZoomInClick, true);
     zoomOutButton.addEventListener('click', handleZoomOutClick, true);
 
     return () => {
+      zoomInButton.removeEventListener('mousedown', handleZoomInPress, true);
+      zoomOutButton.removeEventListener('mousedown', handleZoomOutPress, true);
+      zoomInButton.removeEventListener('touchstart', handleZoomInPress, true);
+      zoomOutButton.removeEventListener('touchstart', handleZoomOutPress, true);
       zoomInButton.removeEventListener('click', handleZoomInClick, true);
       zoomOutButton.removeEventListener('click', handleZoomOutClick, true);
     };

--- a/app/src/components/map/TrailMap.tsx
+++ b/app/src/components/map/TrailMap.tsx
@@ -15,6 +15,8 @@ import {
 import { useManualPicturePlacement } from './hooks/useManualPicturePlacement';
 import { usePictureMarkers } from './hooks/usePictureMarkers';
 import { useTextAnnotationsLayer } from './hooks/useTextAnnotationsLayer';
+import { useRouteLandmarksLayer } from './hooks/useRouteLandmarksLayer';
+import { useRouteLandmarks } from '@/hooks/useRouteLandmarks';
 import { useComparisonTrackLayers } from './hooks/useComparisonTrackLayers';
 import { useBaseMapPresentation } from './hooks/useBaseMapPresentation';
 import { useMapInitialization } from './hooks/useMapInitialization';
@@ -66,6 +68,7 @@ export function TrailMap(_props: TrailMapProps) {
   const addPicture = useAppStore((state) => state.addPicture);
   const removePendingPicturePlacement = useAppStore((state) => state.removePendingPicturePlacement);
   const comparisonTracks = useAppStore((state) => state.comparisonTracks);
+  const landmarks = useRouteLandmarks();
 
   const [isMapLoaded, setIsMapLoaded] = useState(false);
   const [showZoomButtonsHint, setShowZoomButtonsHint] = useState(false);
@@ -144,6 +147,8 @@ export function TrailMap(_props: TrailMapProps) {
     mapRef: map,
     unitSystem: settings.unitSystem,
   });
+
+  useRouteLandmarksLayer({ isMapLoaded, landmarks, mapRef: map });
 
   useComparisonTrackLayers({
     comparisonTracks,

--- a/app/src/components/map/cameraUtils.test.ts
+++ b/app/src/components/map/cameraUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTerrainAwareAdjustments, smoothBearing } from './cameraUtils';
+
+describe('camera utilities', () => {
+  it('holds the heading for small route wiggles', () => {
+    expect(smoothBearing(90, 93)).toBe(90);
+    expect(smoothBearing(359, 1)).toBe(359);
+  });
+
+  it('still turns smoothly once the route makes a meaningful turn', () => {
+    expect(smoothBearing(90, 100, 0.1)).toBe(91);
+  });
+
+  it('uses climb above the route low point rather than absolute altitude', () => {
+    const flatHighRoute = [{ elevation: 1800 }, { elevation: 1820 }];
+    expect(calculateTerrainAwareAdjustments(1800, flatHighRoute, 0).zoomAdjust).toBe(0);
+
+    const climbingRoute = [{ elevation: 600 }, { elevation: 1800 }];
+    expect(calculateTerrainAwareAdjustments(1800, climbingRoute, 1).zoomAdjust).toBeGreaterThan(1.5);
+  });
+});

--- a/app/src/components/map/cameraUtils.test.ts
+++ b/app/src/components/map/cameraUtils.test.ts
@@ -11,6 +11,10 @@ describe('camera utilities', () => {
     expect(smoothBearing(90, 100, 0.1)).toBe(91);
   });
 
+  it('caps a sharp camera turn so it enters the frame progressively', () => {
+    expect(smoothBearing(0, 150)).toBe(1.25);
+  });
+
   it('uses climb above the route low point rather than absolute altitude', () => {
     const flatHighRoute = [{ elevation: 1800 }, { elevation: 1820 }];
     expect(calculateTerrainAwareAdjustments(1800, flatHighRoute, 0).zoomAdjust).toBe(0);

--- a/app/src/components/map/cameraUtils.test.ts
+++ b/app/src/components/map/cameraUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTerrainAwareAdjustments, smoothBearing } from './cameraUtils';
+import { calculateTerrainAwareAdjustments, smoothBearing, smoothZoom } from './cameraUtils';
 
 describe('camera utilities', () => {
   it('holds the heading for small route wiggles', () => {
@@ -13,6 +13,15 @@ describe('camera utilities', () => {
 
   it('caps a sharp camera turn so it enters the frame progressively', () => {
     expect(smoothBearing(0, 150)).toBe(1.25);
+  });
+
+  it('holds zoom steady for tiny terrain-estimation changes', () => {
+    expect(smoothZoom(15, 15.02)).toBe(15);
+  });
+
+  it('zooms in gradually but opens the frame faster when terrain requires it', () => {
+    expect(smoothZoom(15, 16)).toBeCloseTo(15.035);
+    expect(smoothZoom(15, 10)).toBeCloseTo(14.88);
   });
 
   it('uses climb above the route low point rather than absolute altitude', () => {

--- a/app/src/components/map/cameraUtils.ts
+++ b/app/src/components/map/cameraUtils.ts
@@ -1,11 +1,21 @@
 export function smoothBearing(
   currentBearing: number,
   targetBearing: number,
-  smoothingFactor: number = 0.015
+  smoothingFactor: number = 0.015,
+  stabilityDeadbandDegrees: number = 4,
 ): number {
   let diff = targetBearing - currentBearing;
   if (diff > 180) diff -= 360;
   if (diff < -180) diff += 360;
+
+  // GPS traces frequently oscillate by a few degrees on an otherwise straight
+  // section. At a close, pitched camera angle those tiny corrections read as
+  // distracting side-to-side camera movement. Keep the current heading until
+  // the route has made a meaningful turn; larger turns still take the normal
+  // smooth, shortest-path transition below.
+  if (Math.abs(diff) < stabilityDeadbandDegrees) {
+    return (currentBearing + 360) % 360;
+  }
 
   const maxChange = 2;
   const change = Math.max(-maxChange, Math.min(maxChange, diff * smoothingFactor));
@@ -30,7 +40,22 @@ export function calculateTerrainAwareAdjustments(
   elevationData: Array<{ elevation: number; progress?: number }>,
   currentProgress: number
 ): { zoomAdjust: number; pitchAdjust: number } {
-  const elevationRisk = Math.min(Math.max(0, elevation) / TERRAIN_CAMERA_SETTINGS.ELEVATION_RISK_METERS, 1);
+  // Absolute altitude is not what makes a replay camera lose its subject. The
+  // problem is the climb relative to this route's lowest section: a track that
+  // starts at sea level and climbs 1,500 m needs more room, while a flat route
+  // entirely at 1,500 m does not. This also keeps the selected close framing at
+  // the start of an alpine route and expands it progressively on the climb.
+  const finiteElevations = elevationData
+    .map((sample) => sample.elevation)
+    .filter(Number.isFinite);
+  const routeBaseElevation = finiteElevations.length > 0
+    ? Math.min(...finiteElevations)
+    : elevation;
+  const relativeElevation = Math.max(0, elevation - routeBaseElevation);
+  const elevationRisk = Math.min(
+    relativeElevation / TERRAIN_CAMERA_SETTINGS.ELEVATION_RISK_METERS,
+    1,
+  );
 
   let steepnessRisk = 0;
   if (elevationData.length > 2) {

--- a/app/src/components/map/cameraUtils.ts
+++ b/app/src/components/map/cameraUtils.ts
@@ -1,7 +1,7 @@
 export function smoothBearing(
   currentBearing: number,
   targetBearing: number,
-  smoothingFactor: number = 0.015,
+  smoothingFactor: number = 0.03,
   stabilityDeadbandDegrees: number = 4,
 ): number {
   let diff = targetBearing - currentBearing;
@@ -17,7 +17,8 @@ export function smoothBearing(
     return (currentBearing + 360) % 360;
   }
 
-  const maxChange = 2;
+  // Keep sharp switchbacks cinematic rather than snapping the view sideways.
+  const maxChange = 1.25;
   const change = Math.max(-maxChange, Math.min(maxChange, diff * smoothingFactor));
 
   return (currentBearing + change + 360) % 360;

--- a/app/src/components/map/cameraUtils.ts
+++ b/app/src/components/map/cameraUtils.ts
@@ -24,6 +24,30 @@ export function smoothBearing(
   return (currentBearing + change + 360) % 360;
 }
 
+/**
+ * Smooths the terrain-aware follow-camera zoom without letting minor elevation
+ * estimate changes make the view pulse. Zooming in is deliberately slower than
+ * zooming out: opening the frame quickly preserves a safe view of the marker
+ * when the route enters steeper terrain.
+ */
+export function smoothZoom(
+  currentZoom: number,
+  targetZoom: number,
+  smoothingFactor: number = 0.12,
+  stabilityDeadband: number = 0.035,
+): number {
+  const diff = targetZoom - currentZoom;
+
+  if (Math.abs(diff) < stabilityDeadband) {
+    return currentZoom;
+  }
+
+  const maxChange = diff < 0 ? 0.12 : 0.035;
+  const change = Math.max(-maxChange, Math.min(maxChange, diff * smoothingFactor));
+
+  return currentZoom + change;
+}
+
 export const TERRAIN_CAMERA_SETTINGS = {
   ELEVATION_RISK_METERS: 1200,
   STEEPNESS_RISK_FACTOR: 18,

--- a/app/src/components/map/hooks/useRouteLandmarksLayer.ts
+++ b/app/src/components/map/hooks/useRouteLandmarksLayer.ts
@@ -1,0 +1,90 @@
+import { useEffect, type MutableRefObject } from 'react';
+import type { FeatureCollection, Point } from 'geojson';
+import maplibregl from 'maplibre-gl';
+import type { RouteLandmark } from '@/types/landmarks';
+
+const SOURCE = 'route-landmarks';
+const HALO = 'route-landmarks-halo';
+const ICON = 'route-landmarks-icon';
+const LABEL = 'route-landmarks-label';
+const IMAGE_PREFIX = 'route-landmark-glyph-';
+
+// Mapbox Maki v8 icons (CC0): https://github.com/mapbox/maki
+// Kept locally as path data so map rendering has no runtime icon requests.
+const MAKI_PATHS: Record<string, string> = {
+  summit: 'm7.5 1c-.3 0-.4.2-.6.4l-5.8 9.5c-.1.1-.1.3-.1.4 0 .5.4.7.7.7h11.6c.4 0 .7-.2.7-.7 0-.2 0-.2-.1-.4l-5.7-9.5c-.2-.2-.4-.4-.7-.4zm0 1.5 3.3 5.5h-.8l-1.5-1.5-1 1.5-1-1.5-1.5 1.5h-.9z',
+  waypoint: 'm7.5385 1c-.2948 0-.4883.1772-.6154.3846l-5.8462 9.5385c-.0769.0769-.0769.2307-.0769.3846 0 .5385.3846.6923.6923.6923h11.6154c.3846 0 .6923-.1538.6923-.6923 0-.1538 0-.2308-.0769-.3846l-5.7693-9.5385c-.1258-.2081-.3656-.3846-.6153-.3846z',
+  viewpoint: 'M6.02,8.425a2.3859,2.3859,0,0,0-.46.44l-4.55-3.5a7.9976,7.9976,0,0,1,1.51-1.51Zm6.46-4.56-3.5,4.55a2.3971,2.3971,0,0,1,.45.45l4.56-3.5A7.945,7.945,0,0,0,12.48,3.865ZM7.3042,10.0129a1.5,1.5,0,1,0,1.6829,1.2914h0A1.5,1.5,0,0,0,7.3042,10.0129ZM6.43,2.235a7.9329,7.9329,0,0,0-2.06.55l2.2,5.32a2.0438,2.0438,0,0,1,.61-.17Zm2.14.01-.75,5.69a2.49,2.49,0,0,1,.61.16l2.2-5.3A7.2129,7.2129,0,0,0,8.57,2.245Z',
+  town: 'm10.651 6.121c-.0445-.0357-.0999-.05516-.157-.05516s-.1125.01946-.157.05516l-2.245 1.808c-.02881.02323-.05204.05263-.06796.08603-.01593.03341-.02414.06997-.02404.10697v4.625c0 .0671.02666.1315.0741.1789.04745.0474.1118.0741.1789.0741h1.494c.0671 0 .13145-.0267.1789-.0741s.0741-.1118.0741-.1789v-1.747h1v1.747c0 .0671.0267.1315.0741.1789.0475.0474.1118.0741.1789.0741h1.494c.0671 0 .1315-.0267.1789-.0741s.0741-.1118.0741-.1789v-4.627c.0007-.03831-.0074-.07627-.0237-.11095s-.0404-.06514-.0703-.08905zm-.651 3.879h-1v-1h1zm2 0h-1v-1h1zm-6.29-9.184997c-.02299-.034654-.05419-.063081-.09083-.082746s-.07758-.029956-.11917-.029956c-.04158 0-.08252.010291-.11916.029956-.03665.019665-.06785.048092-.09084.082746l-3.248 4.120997c-.02752.0415-.04214.09021-.042.14v7.671c-.00013.0331.00626.0659.0188.0965s.031.0585.0543.082c.02331.0235.05102.0422.08154.0549.03053.0128.06327.0195.09636.0196h2.5c.06632-.0008.12964-.0277.17626-.0749.04661-.0471.07275-.1108.07274-.1771v-1.748h1v1.748c0 .0668.02655.1309.07381.1782s.11136.0738.17819.0738h.748v-6c-.00004-.07511.01684-.14926.04938-.21695.03255-.06769.07993-.12718.13862-.17405l1.812-1.609c0-.05-3.29-4.184997-3.29-4.184997zm-1.71 8.184997h-1v-1h1zm0-3h-1v-1h1zm2 3h-1v-1h1zm0-3h-1v-1h1z',
+  water: 'M7.5 14C9.57688 14 12 12.7117 12 9.43241C12 7.20724 8.53844 2.2883 7.5 1C6.57691 2.2883 3 7.09007 3 9.43241C3 12.7117 5.42312 14 7.5 14Z',
+  waterfall: 'M14 1H5C3.34315 1 2 2.34314 2 4V8.87918C1.39704 9.28261 1 9.96937 1 10.75C1 11.9927 2.00736 13 3.25 13C3.7127 13 4.14279 12.8599 4.5 12.6209C4.85721 12.8599 5.2873 13 5.75 13C6.28601 13 6.77826 12.812 7.16413 12.5H7.51743C8.01909 12.8165 8.61403 13 9.25 13C11.0449 13 12.5 11.5449 12.5 9.75002C12.5 8.39777 11.6747 7.23919 10.5 6.74934V5C10.5 3.89543 11.3954 3 12.5 3H14V1ZM11.5 9.75C11.5 10.9926 10.4926 12 9.25 12C8.71418 12 8.2221 11.8127 7.83567 11.5H6.75009C6.52204 11.8036 6.15895 12 5.75 12C5.34105 12 4.97796 11.8036 4.74991 11.5H4.25009C4.02204 11.8036 3.65895 12 3.25 12C2.55964 12 2 11.4404 2 10.75C2 10.1453 2.42944 9.64082 3 9.525V5.75C3 5.33579 3.33579 5 3.75 5C4.16421 5 4.5 5.33579 4.5 5.75V9C4.5 9.27614 4.72386 9.5 5 9.5C5.27614 9.5 5.5 9.27614 5.5 9V6.75C5.5 6.33579 5.83579 6 6.25 6C6.66421 6 7 6.33579 7 6.75V9C7 9.27614 7.22386 9.5 7.5 9.5C7.77614 9.5 8 9.27614 8 9V5.75C8 5.33579 8.33579 5 8.75 5C9.16421 5 9.5 5.33579 9.5 5.75V7.51373C10.625 7.63809 11.5 8.59186 11.5 9.75Z',
+  shelter: 'M13 2L1 6V8L2 7.66667V13H12V11H4V7L13 4V2Z',
+  camp: 'M14 10V11C14 11.5523 13.5523 12 13 12H2C1.44772 12 1 11.5523 1 11V10C1 9.44772 1.44772 9.00001 2 9.00001H2.25L7.03206 1.25762C7.24699.90965 7.75302.909651 7.96794 1.25762L12.75 9.00001H13C13.5523 9.00001 14 9.44772 14 10ZM10.5 9.00001L7.5 4.00001L4.5 9.00001H10.5Z',
+  pin: 'M5.11697 2.81756C5.76952 2.26561 6.65195 2 7.5 2C8.34805 2 9.23048 2.26561 9.88303 2.81756C10.5075 3.34579 11 4.20017 11 5.56759C11 5.94031 10.8461 6.52407 10.5105 7.29145C10.1859 8.03354 9.73523 8.85087 9.24257 9.65811C8.64175 10.6426 7.999 11.579 7.48195 12.3097C6.96023 11.5798 6.31599 10.6237 5.71947 9.62296C5.2343 8.80934 4.79303 7.98717 4.47608 7.24844C4.14708 6.48162 4 5.91216 4 5.56759C4 4.20017 4.49248 3.34579 5.11697 2.81756Z',
+};
+
+function data(landmarks: RouteLandmark[]): FeatureCollection<Point> {
+  return { type: 'FeatureCollection', features: landmarks.map((landmark) => ({
+    type: 'Feature', geometry: { type: 'Point', coordinates: [landmark.lon, landmark.lat] },
+    properties: {
+      title: landmark.elevation && ['highest-point', 'high-point', 'summit'].includes(landmark.type) ? `${landmark.title}\n${Math.round(landmark.elevation).toLocaleString()} m` : landmark.title,
+      importance: landmark.importance,
+      icon: iconFor(landmark.type),
+      color: landmark.color ?? colorFor(landmark),
+      opacity: landmark.source === 'automatic' ? 0.92 : 1,
+    },
+  })) };
+}
+
+function colorFor(landmark: RouteLandmark) {
+  if (landmark.source === 'user') return '#f3b133';
+  if (['summit', 'high-point', 'highest-point'].includes(landmark.type)) return '#ffd166';
+  if (['pass', 'finish', 'halfway'].includes(landmark.type)) return '#f6d9a8';
+  if (['town', 'trailhead', 'aid-station'].includes(landmark.type)) return '#ff9f6e';
+  if (['lake', 'water', 'waterfall', 'river-crossing'].includes(landmark.type)) return '#69d2ff';
+  if (['hut', 'shelter', 'camp'].includes(landmark.type)) return '#80d6a0';
+  if (landmark.type === 'viewpoint') return '#c9a8ff';
+  return '#f3b133';
+}
+
+function iconFor(type: RouteLandmark['type']) {
+  if (['summit', 'high-point', 'highest-point'].includes(type)) return 'summit';
+  if (['pass', 'halfway', 'finish'].includes(type)) return 'waypoint';
+  if (['town', 'trailhead', 'aid-station'].includes(type)) return 'town';
+  if (type === 'waterfall') return 'waterfall';
+  if (['lake', 'water', 'river-crossing'].includes(type)) return 'water';
+  if (type === 'camp') return 'camp';
+  if (['hut', 'shelter'].includes(type)) return 'shelter';
+  if (type === 'viewpoint') return 'viewpoint';
+  return 'pin';
+}
+
+function glyphImage(kind: string) {
+  const canvas = document.createElement('canvas'); canvas.width = 36; canvas.height = 36;
+  const context = canvas.getContext('2d')!;
+  context.clearRect(0, 0, 36, 36); context.fillStyle = '#ffffff';
+  context.scale(2.4, 2.4);
+  context.fill(new Path2D(MAKI_PATHS[kind] ?? MAKI_PATHS.pin));
+  return context.getImageData(0, 0, 36, 36);
+}
+
+export function useRouteLandmarksLayer({ landmarks, isMapLoaded, mapRef }: { landmarks: RouteLandmark[]; isMapLoaded: boolean; mapRef: MutableRefObject<maplibregl.Map | null> }) {
+  useEffect(() => {
+    const map = mapRef.current; if (!map || !isMapLoaded) return;
+    ['summit', 'waypoint', 'town', 'water', 'waterfall', 'shelter', 'camp', 'viewpoint', 'pin'].forEach((kind) => {
+      const imageId = `${IMAGE_PREFIX}${kind}`;
+      if (!map.hasImage(imageId)) map.addImage(imageId, glyphImage(kind), { sdf: true });
+    });
+    if (!map.getSource(SOURCE)) map.addSource(SOURCE, { type: 'geojson', data: data([]) });
+    if (!map.getLayer(HALO)) map.addLayer({ id: HALO, type: 'circle', source: SOURCE, paint: {
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 9, 9, 15, 15], 'circle-color': '#060a0c', 'circle-opacity': ['*', ['get', 'opacity'], 0.96], 'circle-stroke-color': ['get', 'color'], 'circle-stroke-width': 2.5, 'circle-pitch-alignment': 'viewport',
+    } });
+    if (!map.getLayer(ICON)) map.addLayer({ id: ICON, type: 'symbol', source: SOURCE, layout: {
+      'icon-image': ['concat', IMAGE_PREFIX, ['get', 'icon']], 'icon-size': ['interpolate', ['linear'], ['zoom'], 9, 0.62, 15, 0.92], 'icon-pitch-alignment': 'viewport', 'icon-rotation-alignment': 'viewport', 'icon-allow-overlap': false, 'symbol-sort-key': ['get', 'importance'],
+    }, paint: { 'icon-color': ['get', 'color'], 'icon-opacity': ['get', 'opacity'] } });
+    if (!map.getLayer(LABEL)) map.addLayer({ id: LABEL, type: 'symbol', source: SOURCE, layout: {
+      'text-field': ['get', 'title'], 'text-font': ['Open Sans Bold'], 'text-size': ['interpolate', ['linear'], ['zoom'], 10, 0, 11, 12, 15, 13], 'text-max-width': 11, 'text-offset': [0, 1.7], 'text-anchor': 'top', 'text-optional': true, 'text-pitch-alignment': 'viewport', 'symbol-sort-key': ['get', 'importance'],
+    }, paint: { 'text-color': '#ffffff', 'text-halo-color': '#030506', 'text-halo-width': 3.5, 'text-halo-blur': 0.6, 'text-opacity': ['get', 'opacity'] } });
+    (map.getSource(SOURCE) as maplibregl.GeoJSONSource | undefined)?.setData(data(landmarks));
+  }, [isMapLoaded, landmarks, mapRef]);
+}

--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -19,7 +19,6 @@ interface UseTrailPlaybackCameraParams {
   cameraMode: 'overview' | 'follow' | 'follow-behind';
   completedCoordinates: number[][];
   computedJourney: { coordinates: Array<{ heartRate: number | null }> } | null;
-  currentBearing: number;
   currentIcon: string;
   currentPosition: { lat: number; lon: number } | null;
   currentSegment?: {
@@ -80,7 +79,6 @@ export function useTrailPlaybackCamera({
   cameraMode,
   completedCoordinates,
   computedJourney,
-  currentBearing,
   currentIcon,
   currentPosition,
   currentSegment,
@@ -103,9 +101,6 @@ export function useTrailPlaybackCamera({
 }: UseTrailPlaybackCameraParams) {
   useEffect(() => {
     if (!mapRef.current || !isMapLoaded || !currentPosition) return;
-
-    targetBearingRef.current = currentBearing;
-    smoothBearingRef.current = smoothBearing(smoothBearingRef.current, currentBearing, 0.02);
 
     const shouldShowMarker = trailStyle.showMarker &&
       (animationPhase === 'playing' || (animationPhase === 'idle' && playbackProgress > 0));
@@ -259,6 +254,11 @@ export function useTrailPlaybackCamera({
       });
       if (!targetPose) return;
 
+      // Follow the replay plan's evenly sampled forward heading. Raw GPX
+      // bearings can jump at uneven samples and make tight turns feel abrupt.
+      targetBearingRef.current = targetPose.bearing;
+      smoothBearingRef.current = smoothBearing(smoothBearingRef.current, targetPose.bearing);
+
       const currentZoom = mapRef.current.getZoom();
       const newZoom = currentZoom < targetPose.zoom
         ? Math.min(currentZoom + 0.1, targetPose.zoom)
@@ -307,7 +307,6 @@ export function useTrailPlaybackCamera({
     cameraCoordinates,
     completedCoordinates,
     computedJourney,
-    currentBearing,
     currentIcon,
     currentPosition,
     currentSegment,

--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -8,7 +8,7 @@ import { getHeartRateColor } from '@/utils/gpxParser';
 import { buildSegmentLineFeatures } from '@/utils/trailColorFeatures';
 import { buildColorZoneLineFeatures } from '@/utils/trailColorFeatures';
 import type { TrailColorZone } from '@/types';
-import { smoothBearing } from '@/components/map/cameraUtils';
+import { smoothBearing, smoothZoom } from '@/components/map/cameraUtils';
 import { getIntroCameraPose, getPlaybackCameraPose } from '@/utils/replayCameraPlan';
 
 interface UseTrailPlaybackCameraParams {
@@ -260,9 +260,7 @@ export function useTrailPlaybackCamera({
       smoothBearingRef.current = smoothBearing(smoothBearingRef.current, targetPose.bearing);
 
       const currentZoom = mapRef.current.getZoom();
-      const newZoom = currentZoom < targetPose.zoom
-        ? Math.min(currentZoom + 0.1, targetPose.zoom)
-        : Math.max(currentZoom - 0.1, targetPose.zoom);
+      const newZoom = smoothZoom(currentZoom, targetPose.zoom);
 
       // During deterministic export, camera interpolation must not run on its
       // own clock. The exporter advances playback one frame at a time and waits
@@ -352,7 +350,10 @@ export function useTrailPlaybackCamera({
       mapRef.current.flyTo({
         ...introPose,
         duration: INTRO_DURATION,
-        easing: (value) => 1 - Math.pow(1 - value, 3),
+        // A linear fly-in reaches the playback pose exactly at the end. The
+        // old strong ease-out arrived visually early, which read as a pause
+        // before the marker started moving.
+        easing: (value) => value,
       });
 
       smoothBearingRef.current = introPose.bearing;

--- a/app/src/components/playback/PlaybackProvider.tsx
+++ b/app/src/components/playback/PlaybackProvider.tsx
@@ -6,8 +6,8 @@ interface PlaybackProviderProps {
 }
 
 // Animation timing constants
-const INTRO_DURATION = 2000; // 2 seconds for cinematic zoom-in
-const OUTRO_DELAY = 1000; // 1 second delay before zoom-out
+const INTRO_DURATION = 1500; // Quick cinematic zoom-in without a dead hold
+const OUTRO_DELAY = 0; // Start the final fly-out as soon as the route ends
 const OUTRO_DURATION = 3000; // 3 seconds for zoom-out
 const AUTO_RESET_DELAY = 3000; // 3 seconds after outro before auto-reset
 

--- a/app/src/components/sidebar/ExportPanel.tsx
+++ b/app/src/components/sidebar/ExportPanel.tsx
@@ -93,7 +93,7 @@ export function ExportPanel() {
               </div>
               <div>
                 <span className="opacity-70">{t('export.duration')}:</span>
-                <span className="ml-2 font-bold">{Math.round(playback.totalDuration / 1000 / playback.speed)}s</span>
+                <span className="ml-2 font-bold">{Math.round(playback.totalDuration / 1000)}s</span>
               </div>
             </div>
           </div>

--- a/app/src/components/sidebar/RouteLandmarksEditor.tsx
+++ b/app/src/components/sidebar/RouteLandmarksEditor.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Flag, MapPin, Play, Plus, Trash2 } from 'lucide-react';
+import { useAppStore } from '@/store/useAppStore';
+import { useComputedJourney } from '@/hooks/useComputedJourney';
+import type { LandmarkType } from '@/types/landmarks';
+
+const TYPES: LandmarkType[] = ['custom', 'summit', 'viewpoint', 'hut', 'waterfall', 'camp', 'challenge', 'note'];
+const COLORS = ['#f3b133', '#ff7a59', '#53c16d', '#3b82f6', '#8b5cf6'];
+
+export function RouteLandmarksEditor() {
+  const playback = useAppStore((state) => state.playback);
+  const userLandmarks = useAppStore((state) => state.userLandmarks);
+  const showAutomaticLandmarks = useAppStore((state) => state.showAutomaticLandmarks);
+  const nearbyPlacesEnabled = useAppStore((state) => state.nearbyPlacesEnabled);
+  const nearbyPlacesLoading = useAppStore((state) => state.nearbyPlacesLoading);
+  const nearbyPlacesError = useAppStore((state) => state.nearbyPlacesError);
+  const enrichedLandmarks = useAppStore((state) => state.enrichedLandmarks);
+  const addLandmark = useAppStore((state) => state.addLandmark);
+  const removeLandmark = useAppStore((state) => state.removeLandmark);
+  const setShowAutomaticLandmarks = useAppStore((state) => state.setShowAutomaticLandmarks);
+  const setNearbyPlacesEnabled = useAppStore((state) => state.setNearbyPlacesEnabled);
+  const seekToProgress = useAppStore((state) => state.seekToProgress);
+  const { currentPosition } = useComputedJourney();
+  const [title, setTitle] = useState(''); const [type, setType] = useState<LandmarkType>('custom'); const [color, setColor] = useState(COLORS[0]);
+  const add = () => {
+    if (!currentPosition || !title.trim()) return;
+    addLandmark({ id: crypto.randomUUID(), type, source: 'user', display: 'highlight', lat: currentPosition.lat, lon: currentPosition.lon, progress: playback.progress, elevation: currentPosition.elevation || undefined, title: title.trim(), importance: 5, color });
+    setTitle('');
+  };
+  return <div className="space-y-3 rounded-lg border border-[var(--evergreen)]/15 bg-[var(--evergreen)]/3 p-3">
+    <div className="flex items-center gap-2"><Flag className="h-4 w-4 text-[var(--trail-orange)]" /><p className="text-sm font-medium text-[var(--evergreen)]">Route landmarks</p></div>
+    <p className="text-xs text-[var(--evergreen-60)]">Choose the landscape details you want on the replay. Your route marker remains the visual priority.</p>
+    <label className="flex items-start justify-between gap-3 rounded-lg bg-[var(--canvas)]/60 px-2.5 py-2"><span><span className="block text-xs font-medium text-[var(--evergreen)]">Route moments</span><span className="block pt-0.5 text-[11px] text-[var(--evergreen-60)]">Highest point, major climb/descent, halfway and finish. Off by default.</span></span><input type="checkbox" checked={showAutomaticLandmarks} onChange={(event) => setShowAutomaticLandmarks(event.target.checked)} /></label>
+    <label className="flex items-start justify-between gap-3 rounded-lg bg-[var(--canvas)]/60 px-2.5 py-2"><span><span className="block text-xs font-medium text-[var(--evergreen)]">Nearby named places</span><span className="block pt-0.5 text-[11px] text-[var(--evergreen-60)]">Finds named peaks, passes, lakes, huts and towns near this route using OpenStreetMap.</span></span><input type="checkbox" checked={nearbyPlacesEnabled} onChange={(event) => setNearbyPlacesEnabled(event.target.checked)} /></label>
+    {nearbyPlacesLoading && <p className="text-xs text-[var(--evergreen-60)]">Finding named peaks, lakes and towns near this route…</p>}
+    {nearbyPlacesError && <p className="text-xs text-red-600">{nearbyPlacesError}</p>}
+    {nearbyPlacesEnabled && !nearbyPlacesLoading && !nearbyPlacesError && <p className="text-xs text-[var(--evergreen-60)]">{enrichedLandmarks.length > 0 ? `${enrichedLandmarks.length} named places loaded from OpenStreetMap.` : 'Nearby places load after replay pauses or reaches the end.'}</p>}
+    {nearbyPlacesEnabled && <p className="text-[11px] text-[var(--evergreen-60)]">Nearby-place data © <a className="underline hover:text-[var(--trail-orange)]" href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">OpenStreetMap contributors</a>, available under ODbL.</p>}
+    <input value={title} onChange={(event) => setTitle(event.target.value)} maxLength={48} placeholder="Landmark title" className="w-full rounded-lg border border-[var(--evergreen)]/20 bg-[var(--canvas)] px-3 py-2 text-sm text-[var(--evergreen)] outline-none focus:border-[var(--trail-orange)]" />
+    <div className="flex gap-2"><select value={type} onChange={(event) => setType(event.target.value as LandmarkType)} className="min-w-0 flex-1 rounded-lg border border-[var(--evergreen)]/20 bg-[var(--canvas)] px-2 py-2 text-sm text-[var(--evergreen)]">{TYPES.map((entry) => <option key={entry} value={entry}>{entry.replace('-', ' ')}</option>)}</select><div className="flex items-center gap-1">{COLORS.map((entry) => <button key={entry} type="button" onClick={() => setColor(entry)} className={`h-5 w-5 rounded-full ${color === entry ? 'ring-2 ring-[var(--evergreen)] ring-offset-1' : ''}`} style={{ backgroundColor: entry }} />)}</div></div>
+    <button type="button" onClick={add} disabled={!currentPosition || !title.trim()} className="tr-btn tr-btn-primary inline-flex w-full items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-50"><Plus className="h-4 w-4" />Add landmark</button>
+    {userLandmarks.length > 0 && <div className="space-y-2 border-t border-[var(--evergreen)]/10 pt-3">{userLandmarks.slice().sort((a, b) => (a.progress ?? 0) - (b.progress ?? 0)).map((entry) => <div key={entry.id} className="flex items-center gap-2 text-sm"><MapPin className="h-3.5 w-3.5" style={{ color: entry.color }} /><span className="min-w-0 flex-1 truncate text-[var(--evergreen)]">{entry.title}</span><button type="button" onClick={() => seekToProgress(entry.progress ?? 0)} aria-label={`Go to ${entry.title}`}><Play className="h-4 w-4" /></button><button type="button" onClick={() => removeLandmark(entry.id)} aria-label={`Delete ${entry.title}`}><Trash2 className="h-4 w-4 text-red-500" /></button></div>)}</div>}
+  </div>;
+}

--- a/app/src/components/sidebar/SettingsPanel.tsx
+++ b/app/src/components/sidebar/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store/useAppStore';
 import type { MapStyle, CameraMode, MapOverlays, CameraSettings } from '@/types';
 import { useI18n } from '@/i18n/useI18n';
 import { getFollowBehindZoomLevelForPreset } from '@/utils/followBehindCamera';
+import { RouteLandmarksEditor } from './RouteLandmarksEditor';
 import {
   Map as MapIcon,
   Video,
@@ -204,6 +205,8 @@ export function SettingsPanel() {
         )}
 
       </div>
+
+      <RouteLandmarksEditor />
 
       {/* Map Overlays */}
       <div>

--- a/app/src/components/sidebar/Sidebar.tsx
+++ b/app/src/components/sidebar/Sidebar.tsx
@@ -123,7 +123,9 @@ export function Sidebar() {
               ${isLockedByExport ? 'cursor-not-allowed opacity-45 hover:bg-transparent' : ''}
             `}
           >
-            <tab.icon className="w-4 h-4" />
+            <tab.icon
+              className={tab.id === 'journey' ? 'h-5 w-5 shrink-0 stroke-[2.5]' : 'h-4 w-4 shrink-0'}
+            />
             <span>{tab.label}</span>
             {tab.count > 0 && (
               <span className={`

--- a/app/src/components/sidebar/Sidebar.tsx
+++ b/app/src/components/sidebar/Sidebar.tsx
@@ -123,9 +123,7 @@ export function Sidebar() {
               ${isLockedByExport ? 'cursor-not-allowed opacity-45 hover:bg-transparent' : ''}
             `}
           >
-            <tab.icon
-              className={tab.id === 'journey' ? 'h-5 w-5 shrink-0 stroke-[2.5]' : 'h-4 w-4 shrink-0'}
-            />
+            <tab.icon className="h-4 w-4 shrink-0 stroke-[2.25]" />
             <span>{tab.label}</span>
             {tab.count > 0 && (
               <span className={`

--- a/app/src/components/sidebar/TracksPanel.tsx
+++ b/app/src/components/sidebar/TracksPanel.tsx
@@ -147,16 +147,16 @@ export function TracksPanel() {
       
       {/* Track List */}
       {tracks.length > 0 && (
-        <div>
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-bold text-[var(--evergreen)] uppercase tracking-wide">
+        <section className="border-t border-[var(--evergreen)]/15 pt-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h3 className="text-[11px] font-bold uppercase tracking-[0.1em] text-[var(--evergreen)]">
               {t('tracks.loadedTracks', { count: tracks.length })}
             </h3>
-            <span className="text-xs text-[var(--evergreen-60)]">
+            <span className="whitespace-nowrap text-[11px] text-[var(--evergreen-60)]">
               {t('tracks.dragReorder')}
             </span>
           </div>
-          <div className="space-y-2">
+          <div className="space-y-3">
             {tracks.map((track, index) => (
               <TrackItem
                 key={track.id}
@@ -173,7 +173,7 @@ export function TracksPanel() {
               />
             ))}
           </div>
-        </div>
+        </section>
       )}
       
       {/* Comparison Mode */}

--- a/app/src/components/sidebar/export/ExportSettingsModal.tsx
+++ b/app/src/components/sidebar/export/ExportSettingsModal.tsx
@@ -152,41 +152,6 @@ export function ExportSettingsModal({
           </div>
         </div>
 
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-[var(--evergreen)] mb-2">
-            {t('export.overlays')}
-          </label>
-          <div className="space-y-2">
-            <label className="flex items-center gap-3 cursor-pointer">
-              <div
-                onClick={() => setVideoExportSettings({ includeStats: !videoExportSettings.includeStats })}
-                className={`w-10 h-5 rounded-full transition-colors relative flex-shrink-0 ${
-                  videoExportSettings.includeStats ? 'bg-[var(--trail-orange)]' : 'bg-[var(--evergreen)]/20'
-                }`}
-              >
-                <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
-                  videoExportSettings.includeStats ? 'translate-x-5' : 'translate-x-0.5'
-                }`} />
-              </div>
-              <span className="text-sm text-[var(--evergreen)]">{t('export.statsOverlay')}</span>
-            </label>
-            <label className="flex items-center gap-3 cursor-pointer">
-              <div
-                onClick={() => setVideoExportSettings({ includeElevation: !videoExportSettings.includeElevation })}
-                className={`w-10 h-5 rounded-full transition-colors relative flex-shrink-0 ${
-                  videoExportSettings.includeElevation ? 'bg-[var(--trail-orange)]' : 'bg-[var(--evergreen)]/20'
-                }`}
-              >
-                <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
-                  videoExportSettings.includeElevation ? 'translate-x-5' : 'translate-x-0.5'
-                }`} />
-              </div>
-              <span className="text-sm text-[var(--evergreen)]">{t('export.elevationProfile')}</span>
-            </label>
-            <p className="text-xs text-[var(--evergreen-60)] pl-13">{t('export.logoNote')}</p>
-          </div>
-        </div>
-
         <div className="bg-[var(--evergreen)]/10 rounded-lg p-3 flex items-center gap-2 mb-4">
           <Monitor className="w-4 h-4 text-[var(--evergreen-60)]" />
           <span className="text-sm text-[var(--evergreen)]">

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import fixWebmDuration from 'fix-webm-duration';
 import { useAppStore } from '@/store/useAppStore';
+import { useComputedJourney } from '@/hooks/useComputedJourney';
 import { estimateFileSize } from '@/utils/videoExport';
 import { mapGlobalRef } from '@/utils/mapRef';
 import { useI18n } from '@/i18n/useI18n';
@@ -24,6 +25,18 @@ import {
 } from './mp4CanvasEncoder';
 import { getOverlayRefreshIntervalMs } from './exportOverlay';
 import { useExportOverlayCapture } from './useExportOverlayCapture';
+import { INTRO_DURATION, OUTRO_DELAY, OUTRO_DURATION } from '@/components/playback/PlaybackProvider';
+import {
+  getIntroCameraPose,
+  getOpeningPreloadProgresses,
+  getPlaybackCameraPose,
+  type ReplayCameraPose,
+} from '@/utils/replayCameraPlan';
+
+const EXPORT_MAP_SETTLE_MS = 150;
+const EXPORT_TILE_PRELOAD_TIMEOUT_MS = 6000;
+const EXPORT_OPENING_WINDOW_MS = 20000;
+const EXPORT_OPENING_SAMPLE_COUNT = 8;
 
 function extractCssUrl(value: string): string | null {
   const match = value.match(/url\((['"]?)(.*?)\1\)/);
@@ -71,6 +84,7 @@ export function useVideoExportRecorder() {
   const pictures = useAppStore((state) => state.pictures);
   const journeySegments = useAppStore((state) => state.journeySegments);
   const trailStyle = useAppStore((state) => state.settings.trailStyle);
+  const cameraSettings = useAppStore((state) => state.cameraSettings);
   const playback = useAppStore((state) => state.playback);
   const animationPhase = useAppStore((state) => state.animationPhase);
   const isExporting = useAppStore((state) => state.isExporting);
@@ -84,6 +98,7 @@ export function useVideoExportRecorder() {
   const setSpeed = useAppStore((state) => state.setSpeed);
   const play = useAppStore((state) => state.play);
   const setCinematicPlayed = useAppStore((state) => state.setCinematicPlayed);
+  const { cameraPathCoordinates, elevationData } = useComputedJourney();
 
   const [exportedBlob, setExportedBlob] = useState<Blob | null>(null);
 
@@ -334,6 +349,80 @@ export function useVideoExportRecorder() {
     });
   }, []);
 
+  const preloadExportOpeningTiles = useCallback(async () => {
+    const map = mapGlobalRef.current;
+    if (!map || cameraSettings.mode === 'overview' || cameraPathCoordinates.length === 0) return;
+
+    const routeDurationMs = useAppStore.getState().playback.totalDuration || 60_000;
+    const introPose = getIntroCameraPose({
+      cameraMode: cameraSettings.mode,
+      coordinates: cameraPathCoordinates,
+      elevationData,
+      followBehindZoomLevel: cameraSettings.followBehindZoomLevel,
+      progress: 0,
+    });
+    const poses = [
+      introPose,
+      ...getOpeningPreloadProgresses(
+        routeDurationMs,
+        EXPORT_OPENING_WINDOW_MS,
+        EXPORT_OPENING_SAMPLE_COUNT,
+      ).map((progress) => getPlaybackCameraPose({
+        cameraMode: cameraSettings.mode,
+        coordinates: cameraPathCoordinates,
+        elevationData,
+        followBehindZoomLevel: cameraSettings.followBehindZoomLevel,
+        progress,
+      })),
+    ].filter((pose): pose is ReplayCameraPose => pose !== null);
+
+    const overview = {
+      center: map.getCenter(),
+      zoom: map.getZoom(),
+      pitch: map.getPitch(),
+      bearing: map.getBearing(),
+    };
+    const deadline = Date.now() + EXPORT_TILE_PRELOAD_TIMEOUT_MS;
+
+    for (const pose of poses) {
+      if (recordingCancelledRef.current || Date.now() >= deadline) break;
+      map.jumpTo(pose);
+      await new Promise<void>((resolve) => {
+        let complete = false;
+        const finish = () => {
+          if (complete) return;
+          complete = true;
+          map.off('idle', finish);
+          resolve();
+        };
+        map.once('idle', finish);
+        window.setTimeout(finish, Math.max(0, deadline - Date.now()));
+      });
+    }
+
+    map.jumpTo(overview);
+    await waitForMapFrame();
+  }, [cameraPathCoordinates, cameraSettings.followBehindZoomLevel, cameraSettings.mode, elevationData, waitForMapFrame]);
+
+  const captureDeterministicPhase = useCallback(async (
+    durationMs: number,
+    timestampOffsetMs: number,
+  ) => {
+    const frameDurationMs = 1000 / videoExportSettings.fps;
+    const frameCount = Math.max(1, Math.ceil(durationMs / frameDurationMs));
+
+    for (let frameIndex = 0; frameIndex <= frameCount; frameIndex += 1) {
+      if (!isRecordingRef.current || recordingCancelledRef.current) break;
+      await waitForMapFrame();
+      if (!isRecordingRef.current || recordingCancelledRef.current) break;
+      captureFrame();
+      await encodeWebCodecsFrame((timestampOffsetMs + (frameIndex * frameDurationMs)) * 1000);
+      if (frameIndex < frameCount) {
+        await new Promise<void>((resolve) => window.setTimeout(resolve, frameDurationMs));
+      }
+    }
+  }, [captureFrame, encodeWebCodecsFrame, videoExportSettings.fps, waitForMapFrame]);
+
   // Flush and download the WebCodecs-encoded MP4 once recording has stopped.
   const finalizeWebCodecsExport = useCallback(async () => {
     const encoder = mp4EncoderRef.current;
@@ -436,11 +525,24 @@ export function useVideoExportRecorder() {
     const progressUpdateInterval = Math.max(1, Math.round(fps / 5));
 
     setIsDeterministicExport(true);
-    store.setCinematicPlayed(true);
     store.setPlayback({ isPlaying: true, currentTime: 0, progress: 0 });
-    store.setAnimationPhase('playing');
+    // Start the cinematic movement first and wait for its first rendered frame.
+    // This ensures the video begins from the actual introductory camera pose,
+    // rather than catching the map halfway through a state transition.
+    store.setCinematicPlayed(false);
+    store.setAnimationPhase('intro');
+    await waitForMapFrame();
+    await captureDeterministicPhase(INTRO_DURATION, 0);
 
-    for (let frameIndex = 0; frameIndex <= frameCount; frameIndex += 1) {
+    if (!isRecordingRef.current || recordingCancelledRef.current) return;
+
+    store.setCinematicPlayed(true);
+    store.setAnimationPhase('playing');
+    let encodedDurationMs = INTRO_DURATION;
+
+    // The intro already contains the progress-zero pose. Begin at the first
+    // advancing route frame so the cut into the route has no duplicate hold.
+    for (let frameIndex = 1; frameIndex <= frameCount; frameIndex += 1) {
       if (!isRecordingRef.current || recordingCancelledRef.current) break;
 
       const currentTime = Math.min(routeDurationMs, frameIndex * frameDurationMs * speed);
@@ -450,7 +552,7 @@ export function useVideoExportRecorder() {
 
       if (!isRecordingRef.current || recordingCancelledRef.current) break;
       captureFrame();
-      await encodeWebCodecsFrame(frameIndex * frameDurationMs * 1000);
+      await encodeWebCodecsFrame((encodedDurationMs + (frameIndex * frameDurationMs)) * 1000);
 
       if (frameIndex % progressUpdateInterval === 0 || frameIndex === frameCount) {
         setExportProgress(progress * 100);
@@ -458,8 +560,24 @@ export function useVideoExportRecorder() {
       }
     }
 
+    encodedDurationMs += frameCount * frameDurationMs;
+    if (!recordingCancelledRef.current && isRecordingRef.current) {
+      // Mirror the on-screen finale: a short hold at the finish, then the
+      // outward camera move. Both are encoded before the file is finalized.
+      store.setPlayback({ isPlaying: false, currentTime: routeDurationMs, progress: 1 });
+      if (OUTRO_DELAY > 0) {
+        store.setAnimationPhase('playing');
+        await captureDeterministicPhase(OUTRO_DELAY, encodedDurationMs);
+        encodedDurationMs += OUTRO_DELAY;
+      }
+
+      if (!isRecordingRef.current || recordingCancelledRef.current) return;
+      store.setAnimationPhase('outro');
+      await captureDeterministicPhase(OUTRO_DURATION, encodedDurationMs);
+    }
+
     if (!recordingCancelledRef.current) finishRecording();
-  }, [captureFrame, encodeWebCodecsFrame, finishRecording, setExportProgress, setExportStage, setIsDeterministicExport, t, videoExportSettings, waitForMapFrame]);
+  }, [captureDeterministicPhase, captureFrame, encodeWebCodecsFrame, finishRecording, setExportProgress, setExportStage, setIsDeterministicExport, t, videoExportSettings, waitForMapFrame]);
 
   useEffect(() => {
     if (!isRecordingRef.current) return;
@@ -645,7 +763,12 @@ export function useVideoExportRecorder() {
       setSpeed(exportSpeed);
       setCinematicPlayed(false);
 
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      setExportStage(t('export.stagePreparing'));
+      await preloadExportOpeningTiles();
+
+      // Let MapLibre complete its reset pose before starting the intro and its
+      // first encoded frame. This avoids a recording that begins mid-reframe.
+      await new Promise((resolve) => setTimeout(resolve, EXPORT_MAP_SETTLE_MS));
 
       setExportStage(t('export.stageSetupRecorder'));
 
@@ -705,7 +828,7 @@ export function useVideoExportRecorder() {
       }
       useWebCodecsRef.current = false;
     }
-  }, [actualFormat, finishRecording, includeElevation, includeStats, journeySegments.length, loadHtml2Canvas, pictures.length, play, playback.totalDuration, resetOverlayCapture, resetPlayback, runDeterministicExport, setCinematicPlayed, setExportProgress, setExportStage, setIsDeterministicExport, setIsExporting, setSpeed, setupMediaRecorderFallback, startFrameCapture, t, tracks.length, updateOverlayAsync, videoExportSettings]);
+  }, [actualFormat, finishRecording, includeElevation, includeStats, journeySegments.length, loadHtml2Canvas, pictures.length, play, playback.totalDuration, preloadExportOpeningTiles, resetOverlayCapture, resetPlayback, runDeterministicExport, setCinematicPlayed, setExportProgress, setExportStage, setIsDeterministicExport, setIsExporting, setSpeed, setupMediaRecorderFallback, startFrameCapture, t, tracks.length, updateOverlayAsync, videoExportSettings]);
 
   const handleCancelExport = useCallback(() => {
     const exportEncoderPath = useWebCodecsRef.current ? 'webcodecs' : 'mediarecorder';

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -65,6 +65,8 @@ function drawTintedSvgIcon(
 export function useVideoExportRecorder() {
   const { t } = useI18n();
   const videoExportSettings = useAppStore((state) => state.videoExportSettings);
+  const visibleStats = useAppStore((state) => state.settings.visibleStats);
+  const showElevationProfile = useAppStore((state) => state.settings.showElevationProfile);
   const tracks = useAppStore((state) => state.tracks);
   const pictures = useAppStore((state) => state.pictures);
   const journeySegments = useAppStore((state) => state.journeySegments);
@@ -93,6 +95,8 @@ export function useVideoExportRecorder() {
   );
   const actualFormat = videoExportSettings.format === 'mp4' && !mp4Supported ? 'webm' : videoExportSettings.format;
   const estimatedSize = estimateFileSize(playback.totalDuration, videoExportSettings);
+  const includeStats = visibleStats.length > 0;
+  const includeElevation = showElevationProfile;
   const overlayRefreshIntervalMs = useMemo(() => getOverlayRefreshIntervalMs(videoExportSettings.fps), [videoExportSettings.fps]);
   const {
     cachedOverlayRef,
@@ -102,8 +106,8 @@ export function useVideoExportRecorder() {
     resetOverlayCapture,
     updateOverlayAsync,
   } = useExportOverlayCapture({
-    includeElevation: videoExportSettings.includeElevation,
-    includeStats: videoExportSettings.includeStats,
+    includeElevation,
+    includeStats,
   });
 
   const recordingCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -599,8 +603,8 @@ export function useVideoExportRecorder() {
       export_quality: videoExportSettings.quality,
       export_fps: videoExportSettings.fps,
       export_aspect_ratio: videoExportSettings.aspectRatio,
-      export_include_stats: videoExportSettings.includeStats,
-      export_include_elevation: videoExportSettings.includeElevation,
+      export_include_stats: includeStats,
+      export_include_elevation: includeElevation,
       export_duration_bucket: getDurationBucket(playback.totalDuration),
       track_count: tracks.length,
       picture_count: pictures.length,
@@ -701,7 +705,7 @@ export function useVideoExportRecorder() {
       }
       useWebCodecsRef.current = false;
     }
-  }, [actualFormat, finishRecording, journeySegments.length, loadHtml2Canvas, pictures.length, play, playback.totalDuration, resetOverlayCapture, resetPlayback, runDeterministicExport, setCinematicPlayed, setExportProgress, setExportStage, setIsDeterministicExport, setIsExporting, setSpeed, setupMediaRecorderFallback, startFrameCapture, t, tracks.length, updateOverlayAsync, videoExportSettings]);
+  }, [actualFormat, finishRecording, includeElevation, includeStats, journeySegments.length, loadHtml2Canvas, pictures.length, play, playback.totalDuration, resetOverlayCapture, resetPlayback, runDeterministicExport, setCinematicPlayed, setExportProgress, setExportStage, setIsDeterministicExport, setIsExporting, setSpeed, setupMediaRecorderFallback, startFrameCapture, t, tracks.length, updateOverlayAsync, videoExportSettings]);
 
   const handleCancelExport = useCallback(() => {
     const exportEncoderPath = useWebCodecsRef.current ? 'webcodecs' : 'mediarecorder';

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -520,8 +520,9 @@ export function useVideoExportRecorder() {
     const frameDurationMs = 1000 / fps;
     const store = useAppStore.getState();
     const routeDurationMs = store.playback.totalDuration;
-    const speed = store.playback.speed;
-    const frameCount = Math.ceil(routeDurationMs / (frameDurationMs * speed));
+    // Preview speed only affects interactive playback. Export always preserves
+    // the configured journey duration on the encoded timeline.
+    const frameCount = Math.ceil(routeDurationMs / frameDurationMs);
     const progressUpdateInterval = Math.max(1, Math.round(fps / 5));
 
     setIsDeterministicExport(true);
@@ -545,7 +546,7 @@ export function useVideoExportRecorder() {
     for (let frameIndex = 1; frameIndex <= frameCount; frameIndex += 1) {
       if (!isRecordingRef.current || recordingCancelledRef.current) break;
 
-      const currentTime = Math.min(routeDurationMs, frameIndex * frameDurationMs * speed);
+      const currentTime = Math.min(routeDurationMs, frameIndex * frameDurationMs);
       const progress = routeDurationMs > 0 ? currentTime / routeDurationMs : 1;
       useAppStore.getState().setPlayback({ currentTime, progress });
       await waitForMapFrame();

--- a/app/src/components/sidebar/tracks/TrackItem.tsx
+++ b/app/src/components/sidebar/tracks/TrackItem.tsx
@@ -4,6 +4,7 @@ import {
   Eye,
   EyeOff,
   GripVertical,
+  Mountain,
   Navigation,
   Palette,
   Play,
@@ -77,19 +78,24 @@ export function TrackItem({
       }}
       onDrop={handleDrop}
       className={`
-        tr-journey-segment p-3 cursor-move transition-all
-        ${isActive ? 'active ring-2 ring-[var(--trail-orange)]' : ''}
+        cursor-move overflow-hidden rounded-xl border bg-white/70 shadow-[0_8px_20px_rgba(27,42,32,0.06)] transition-colors
+        ${isActive ? 'border-[var(--trail-orange)] bg-[var(--trail-orange-15)] shadow-[0_10px_24px_rgba(193,101,47,0.13)]' : 'border-[var(--evergreen)]/16 hover:border-[var(--evergreen)]/30'}
         ${isDragging ? 'opacity-50' : ''}
       `}
     >
-      <div className="flex items-start gap-2">
-        <GripVertical className="mt-1 h-4 w-4 text-[var(--evergreen-40)]" />
+      <div className="flex items-stretch gap-3 p-3">
+        <div className="flex w-4 shrink-0 flex-col items-center gap-2 pt-0.5">
+          <GripVertical className="h-4 w-4 text-[var(--evergreen-40)]" />
+          <span className="min-h-8 w-1 flex-1 rounded-full" style={{ backgroundColor: track.color }} />
+        </div>
 
         <div className="min-w-0 flex-1">
-          <div className="mb-2 flex items-center gap-2">
+          <div className="flex items-center gap-2">
             <button
               onClick={onToggleVisibility}
-              className="text-[var(--evergreen-60)] hover:text-[var(--evergreen)]"
+              className="shrink-0 rounded-md p-1 text-[var(--evergreen-60)] transition-colors hover:bg-[var(--evergreen)]/8 hover:text-[var(--evergreen)]"
+              aria-label={track.visible ? 'Hide track' : 'Show track'}
+              title={track.visible ? 'Hide track' : 'Show track'}
             >
               {track.visible ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
             </button>
@@ -132,7 +138,9 @@ export function TrackItem({
             <div className="flex items-center gap-1">
               <button
                 onClick={() => setShowColorPicker(!showColorPicker)}
-                className="rounded p-1 hover:bg-[var(--evergreen)]/10"
+                className="rounded-md p-1 transition-colors hover:bg-[var(--evergreen)]/10"
+                aria-label="Change track color"
+                title="Change track color"
               >
                 <Palette className="h-4 w-4 text-[var(--evergreen-60)]" />
               </button>
@@ -140,80 +148,44 @@ export function TrackItem({
               <button
                 onClick={onActivate}
                 className={`
-                  rounded p-1
+                  rounded-md p-1 transition-colors
                   ${isActive
                     ? 'bg-[var(--trail-orange)] text-[var(--canvas)]'
                     : 'hover:bg-[var(--evergreen)]/10'}
                 `}
+                aria-label="Use this track"
+                title="Use this track"
               >
                 <Play className="h-4 w-4" />
               </button>
 
               <button
                 onClick={onRemove}
-                className="rounded p-1 text-red-500 hover:bg-red-100"
+                className="rounded-md p-1 text-red-500 transition-colors hover:bg-red-100"
+                aria-label="Remove track"
+                title="Remove track"
               >
                 <Trash2 className="h-4 w-4" />
               </button>
             </div>
           </div>
 
-          <div className="grid grid-cols-3 gap-2 text-xs">
-            <div className="rounded-lg border border-[var(--evergreen)]/10 bg-[var(--evergreen)]/4 p-2.5">
-              <div className="mb-1 flex items-center gap-1 text-[var(--evergreen-60)]">
-                <Navigation className="h-3 w-3" />
-                <span className="text-[10px] font-medium uppercase tracking-[0.06em]">{t('tracks.distance')}</span>
-              </div>
-              <span className="text-sm font-semibold text-[var(--evergreen)]">
-                {formatDistance(track.totalDistance, settings.unitSystem)}
-              </span>
-            </div>
+          <dl className="mt-3 grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--evergreen)]/12 bg-[var(--evergreen)]/[0.035] text-xs">
+            <TrackMetric icon={<Navigation className="h-3.5 w-3.5" />} label={t('tracks.distance')} value={formatDistance(track.totalDistance, settings.unitSystem)} />
+            <TrackMetric icon={<Clock className="h-3.5 w-3.5" />} label={t('tracks.time')} value={formatDuration(track.movingTime || track.totalTime)} className="border-l border-[var(--evergreen)]/10" />
+            <TrackMetric icon={<TrendingUp className="h-3.5 w-3.5" />} label={t('tracks.speed')} value={formatSpeedFromKmh(track.avgMovingSpeed || track.avgSpeed, settings.unitSystem)} detail={pace > 0 ? `${Math.floor(pace)}:${String(Math.round((pace % 1) * 60)).padStart(2, '0')}/km` : undefined} className="border-t border-[var(--evergreen)]/10" />
+            <TrackMetric icon={<Mountain className="h-3.5 w-3.5" />} label={t('tracks.gain')} value={formatElevation(track.elevationGain, settings.unitSystem)} detail={`${formatElevation(track.elevationLoss, settings.unitSystem)} ${t('tracks.loss')}`} className="border-l border-t border-[var(--evergreen)]/10" />
+          </dl>
 
-            <div className="rounded-lg border border-[var(--evergreen)]/10 bg-[var(--evergreen)]/4 p-2.5">
-              <div className="mb-1 flex items-center gap-1 text-[var(--evergreen-60)]">
-                <Clock className="h-3 w-3" />
-                <span className="text-[10px] font-medium uppercase tracking-[0.06em]">{t('tracks.time')}</span>
-              </div>
-              <span className="text-sm font-semibold text-[var(--evergreen)]">
-                {formatDuration(track.movingTime || track.totalTime)}
-              </span>
-            </div>
-
-            <div className="rounded-lg border border-[var(--evergreen)]/10 bg-[var(--evergreen)]/4 p-2.5">
-              <div className="mb-1 flex items-center gap-1 text-[var(--evergreen-60)]">
-                <TrendingUp className="h-3 w-3" />
-                <span className="text-[10px] font-medium uppercase tracking-[0.06em]">{t('tracks.speed')}</span>
-              </div>
-              <span className="text-sm font-semibold text-[var(--evergreen)]">
-                {formatSpeedFromKmh(track.avgMovingSpeed || track.avgSpeed, settings.unitSystem)}
-              </span>
-              {pace > 0 && (
-                <span className="mt-0.5 block text-[10px] text-[var(--evergreen-60)]">
-                  ({Math.floor(pace)}:{String(Math.round((pace % 1) * 60)).padStart(2, '0')}/km)
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-[var(--evergreen-60)]">
-            <span className="rounded-full border border-[var(--evergreen)]/10 bg-white/70 px-2.5 py-1">
-              ↑ {formatElevation(track.elevationGain, settings.unitSystem)} {t('tracks.gain')}
-            </span>
-            <span className="rounded-full border border-[var(--evergreen)]/10 bg-white/70 px-2.5 py-1">
-              ↓ {formatElevation(track.elevationLoss, settings.unitSystem)} {t('tracks.loss')}
-            </span>
-            <span className="rounded-full border border-[var(--evergreen)]/10 bg-white/70 px-2.5 py-1">
-              ⚡ {formatSpeedFromKmh(track.maxSpeed, settings.unitSystem)} {t('tracks.max')}
-            </span>
-            <span className="rounded-full border border-[var(--evergreen)]/10 bg-white/70 px-2.5 py-1">
-              {track.points.length.toLocaleString()} {t('tracks.points')}
-            </span>
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-medium text-[var(--evergreen-60)]">
+            <span>{t('tracks.max')} {formatSpeedFromKmh(track.maxSpeed, settings.unitSystem)}</span>
+            <span>{track.points.length.toLocaleString()} {t('tracks.points')}</span>
           </div>
         </div>
       </div>
 
       {showColorPicker && (
-        <div className="mt-2 flex flex-wrap gap-1">
+        <div className="flex flex-wrap gap-1.5 border-t border-[var(--evergreen)]/10 bg-[var(--evergreen)]/[0.025] px-3 py-2.5 pl-10">
           {TRACK_COLORS.map((color) => (
             <button
               key={color}
@@ -230,6 +202,25 @@ export function TrackItem({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function TrackMetric({ icon, label, value, detail, className = '' }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  detail?: string;
+  className?: string;
+}) {
+  return (
+    <div className={`min-w-0 px-2.5 py-2 ${className}`}>
+      <dt className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--evergreen-60)]">
+        {icon}
+        <span className="truncate">{label}</span>
+      </dt>
+      <dd className="mt-1 truncate text-sm font-semibold tabular-nums text-[var(--evergreen)]">{value}</dd>
+      {detail && <p className="mt-0.5 truncate text-[10px] tabular-nums text-[var(--evergreen-60)]">{detail}</p>}
     </div>
   );
 }

--- a/app/src/components/stats/StatsOverlay.tsx
+++ b/app/src/components/stats/StatsOverlay.tsx
@@ -247,15 +247,15 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
     <div
       className={`tr-stats-overlay ${
         isExportVariant
-          ? 'tr-stats-overlay--compact tr-stats-overlay--export max-w-[15.5rem]'
+          ? 'tr-stats-overlay--compact tr-stats-overlay--export'
           : isNarrowLayout
-            ? 'tr-stats-overlay--compact tr-stats-overlay--narrow max-w-[19.5rem]'
-            : 'max-w-[25.5rem]'
+            ? 'tr-stats-overlay--compact tr-stats-overlay--narrow'
+            : ''
       }`}
     >
       <div
-        className={`grid ${isExportVariant || isNarrowLayout ? 'gap-x-1.5 gap-y-1.5 mb-0' : 'gap-2 mb-0'}`}
-        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+        className={`grid w-max ${isExportVariant || isNarrowLayout ? 'gap-x-1.5 gap-y-1.5 mb-0' : 'gap-2 mb-0'}`}
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(max-content, 1fr))` }}
       >
         {visibleStats.map((stat) => (
           <StatItem
@@ -291,7 +291,7 @@ interface StatItemProps {
 
 function StatItem({ icon, label, value, compact = false, exportCompact = false }: StatItemProps) {
   return (
-    <div className={`min-w-0 text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}>
+    <div className={`min-w-max text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}>
       <div className={`flex items-center justify-center min-w-0 ${
         exportCompact ? 'gap-1 mb-0.5' : compact ? 'gap-1 mb-1' : 'gap-1.5 mb-1.5'
       }`}>
@@ -300,14 +300,14 @@ function StatItem({ icon, label, value, compact = false, exportCompact = false }
         }`}>
           {icon}
         </span>
-        <span className={`block min-w-0 ${
+        <span className={`block min-w-0 whitespace-nowrap ${
           exportCompact ? 'text-[7px] text-white' : compact ? 'text-[9px] text-white' : 'text-[10px] text-white'
         } font-semibold uppercase tracking-[0.08em] leading-[1.1]`}>
           {label}
         </span>
       </div>
       <div
-        className={`tr-stat-value flex min-h-[1.2rem] items-center justify-center px-0.5 text-center font-semibold tabular-nums tracking-[-0.03em] ${
+        className={`tr-stat-value flex min-h-[1.2rem] items-center justify-center whitespace-nowrap px-0.5 text-center font-semibold tabular-nums tracking-[-0.03em] ${
           exportCompact ? 'text-[9px] leading-[1.05] text-white' : compact ? 'text-[11px] leading-[1.1]' : 'text-[12px] leading-[1.1]'
         }`}
         title={value}

--- a/app/src/help/helpContent.ts
+++ b/app/src/help/helpContent.ts
@@ -22,6 +22,12 @@ export function getTutorialVideos(t: Translate) {
       src: '/media/video/comparison-mode-demo.mp4',
       downloadLabel: t('help.tutorial.videos.comparison.downloadLabel'),
     },
+    {
+      title: t('help.tutorial.videos.aranLandmarks.title'),
+      description: t('help.tutorial.videos.aranLandmarks.description'),
+      src: '/media/video/aran-by-utmb-landmarks-demo.mp4',
+      downloadLabel: t('help.tutorial.videos.aranLandmarks.downloadLabel'),
+    },
   ];
 }
 

--- a/app/src/hooks/useRouteLandmarks.ts
+++ b/app/src/hooks/useRouteLandmarks.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo } from 'react';
+import { useAppStore } from '@/store/useAppStore';
+import { useComputedJourney } from '@/hooks/useComputedJourney';
+import { analyzeRouteLandmarks } from '@/utils/routeLandmarks';
+import { resolveRouteLandmarks } from '@/utils/resolveRouteLandmarks';
+import { selectVisibleLandmarks } from '@/utils/landmarkVisibility';
+import type { RouteLandmark } from '@/types/landmarks';
+import { projectCoordinateToJourney, projectCoordinateToTrack } from '@/utils/routeProjection';
+
+export function useRouteLandmarks(): RouteLandmark[] {
+  const userLandmarks = useAppStore((state) => state.userLandmarks);
+  const showAutomaticLandmarks = useAppStore((state) => state.showAutomaticLandmarks);
+  const enrichedLandmarks = useAppStore((state) => state.enrichedLandmarks);
+  const nearbyPlacesEnabled = useAppStore((state) => state.nearbyPlacesEnabled);
+  const setEnrichedLandmarks = useAppStore((state) => state.setEnrichedLandmarks);
+  const setNearbyPlacesStatus = useAppStore((state) => state.setNearbyPlacesStatus);
+  const groups = useAppStore((state) => state.enabledLandmarkGroups);
+  const playback = useAppStore((state) => state.playback);
+  const cameraSettings = useAppStore((state) => state.cameraSettings);
+  const { computedJourney, activeTrack, totalDistance } = useComputedJourney();
+  const isExporting = useAppStore((state) => state.isExporting);
+  const routePoints = useMemo(() => computedJourney?.coordinates ?? activeTrack?.points ?? [], [activeTrack?.points, computedJourney?.coordinates]);
+  useEffect(() => {
+    // A completed replay can retain its playing flag briefly while the outro
+    // settles. It is safe to enrich then, but never during an active frame.
+    if (!nearbyPlacesEnabled || isExporting || (playback.isPlaying && playback.progress < 1) || routePoints.length < 2) return;
+    const controller = new AbortController();
+    const points = routePoints.filter((_, index) => index === 0 || index === routePoints.length - 1 || index % Math.ceil(routePoints.length / 160) === 0)
+      .map((point) => [Number(point.lon.toFixed(5)), Number(point.lat.toFixed(5))]);
+    setNearbyPlacesStatus(true);
+    fetch('/api/landmarks', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ points }), signal: controller.signal })
+      .then(async (response) => {
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.error || 'Could not find nearby places');
+        const landmarks = (payload.landmarks as Array<Omit<RouteLandmark, 'progress' | 'routeDistanceMeters'>>).map((place) => {
+          const match = computedJourney
+            ? projectCoordinateToJourney(computedJourney, place.lat, place.lon, 0)
+            : activeTrack ? projectCoordinateToTrack(activeTrack, place.lat, place.lon, 0) : null;
+          // Preserve the OSM feature's real-world position for map rendering.
+          // The route projection only supplies replay timing and proximity.
+          return match && match.distanceMeters <= 1_500
+            ? { ...place, progress: match.progress, routeDistanceMeters: match.progress * totalDistance }
+            : null;
+        }).filter((place): place is NonNullable<typeof place> => place !== null)
+          .sort((a, b) => b.importance - a.importance)
+          .slice(0, 24);
+        setEnrichedLandmarks(landmarks);
+        setNearbyPlacesStatus(false);
+      })
+      .catch((error: unknown) => { if (!controller.signal.aborted) setNearbyPlacesStatus(false, error instanceof Error ? error.message : 'Could not find nearby places'); });
+    return () => controller.abort();
+  }, [activeTrack, computedJourney, isExporting, nearbyPlacesEnabled, playback.isPlaying, playback.progress, routePoints, setEnrichedLandmarks, setNearbyPlacesStatus, totalDistance]);
+  const automatic = useMemo(() => analyzeRouteLandmarks(
+    computedJourney?.coordinates ?? activeTrack?.points ?? [],
+  ), [activeTrack?.points, computedJourney?.coordinates]);
+  return useMemo(() => {
+    const merged = resolveRouteLandmarks([...(showAutomaticLandmarks ? automatic : []), ...enrichedLandmarks, ...userLandmarks]);
+    const enabled = groups.length ? merged.filter((landmark) => groups.includes(landmark.type) || landmark.source === 'user') : merged;
+    return selectVisibleLandmarks(enabled, {
+      mode: cameraSettings.mode,
+      preset: cameraSettings.followBehindPreset,
+      progress: playback.progress,
+      totalDistanceMeters: totalDistance,
+    });
+  }, [automatic, cameraSettings.followBehindPreset, cameraSettings.mode, enrichedLandmarks, groups, playback.progress, showAutomaticLandmarks, totalDistance, userLandmarks]);
+}

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -520,6 +520,11 @@ export const ca = {
           description: 'Dos fitxers GPX reproduïts alhora per comparar ritme, decisions de ruta i temps.',
           downloadLabel: 'Descarregar demo de comparació',
         },
+        aranLandmarks: {
+          title: 'Ruta d’Aran by UTMB amb anotacions',
+          description: 'Un replay quadrat amb pobles, llocs amb nom i anotacions de ruta al recorregut d’Aran by UTMB.',
+          downloadLabel: 'Descarregar demo d’Aran by UTMB',
+        },
       },
       sampleTracks: {
         camins: {

--- a/app/src/i18n/locales/de.ts
+++ b/app/src/i18n/locales/de.ts
@@ -520,6 +520,11 @@ export const de = {
           description: 'Zwei GPX-Dateien werden zusammen wiedergegeben, um Tempo, Routenauswahl und Timing zu vergleichen.',
           downloadLabel: 'Laden Sie die Demo zum Vergleichsmodus herunter',
         },
+        aranLandmarks: {
+          title: 'Aran by UTMB Route mit Markierungen',
+          description: 'Eine quadratische Routenwiedergabe mit Orten, benannten Plätzen und Anmerkungen entlang der Aran by UTMB Strecke.',
+          downloadLabel: 'Aran by UTMB Demo herunterladen',
+        },
       },
       sampleTracks: {
         camins: {

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -520,6 +520,11 @@ export const en = {
           description: 'Two GPX files replayed together to compare pace, route choices, and timing.',
           downloadLabel: 'Download comparison mode demo',
         },
+        aranLandmarks: {
+          title: "Aran by UTMB route with landmarks",
+          description: 'A square route replay showing named places and route annotations across the Aran by UTMB course.',
+          downloadLabel: 'Download Aran by UTMB demo',
+        },
       },
       sampleTracks: {
         camins: {

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -520,6 +520,11 @@ export const es = {
           description: 'Dos archivos GPX reproducidos a la vez para comparar ritmo, decisiones de ruta y tiempos.',
           downloadLabel: 'Descargar demo de comparación',
         },
+        aranLandmarks: {
+          title: 'Ruta de Aran by UTMB con anotaciones',
+          description: 'Un replay cuadrado con pueblos, lugares con nombre y anotaciones de ruta en el recorrido de Aran by UTMB.',
+          downloadLabel: 'Descargar demo de Aran by UTMB',
+        },
       },
       sampleTracks: {
         camins: {

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -520,6 +520,11 @@ help: {
         description: 'Deux fichiers GPX rejoués simultanément afin de comparer allure, itinéraire et chronologie.',
         downloadLabel: 'Télécharger l\'exemple du mode comparaison',
       },
+      aranLandmarks: {
+        title: 'Parcours Aran by UTMB avec annotations',
+        description: 'Un replay carré avec villages, lieux nommés et annotations le long du parcours Aran by UTMB.',
+        downloadLabel: 'Télécharger la démo Aran by UTMB',
+      },
     },
     sampleTracks: {
       camins: {

--- a/app/src/store/createAppStore.ts
+++ b/app/src/store/createAppStore.ts
@@ -14,6 +14,7 @@ import { createPlaybackSlice } from '@/store/slices/playbackSlice';
 import { createSettingsSlice } from '@/store/slices/settingsSlice';
 import { createTracksSlice } from '@/store/slices/tracksSlice';
 import { createUiSlice } from '@/store/slices/uiSlice';
+import { createLandmarksSlice } from '@/store/slices/landmarksSlice';
 
 export function createAppStore() {
   return create<AppState>()(
@@ -24,6 +25,7 @@ export function createAppStore() {
       ...createPlaybackSlice(set, get, store),
       ...createSettingsSlice(set, get, store),
       ...createUiSlice(set, get, store),
+      ...createLandmarksSlice(set, get, store),
 
       reset: () =>
         set((state) => {
@@ -37,6 +39,13 @@ export function createAppStore() {
           state.videos = [];
           state.iconChanges = [];
           state.textAnnotations = [];
+          state.userLandmarks = [];
+          state.enrichedLandmarks = [];
+          state.showAutomaticLandmarks = false;
+          state.enabledLandmarkGroups = [];
+          state.nearbyPlacesEnabled = false;
+          state.nearbyPlacesLoading = false;
+          state.nearbyPlacesError = null;
           state.playback = createDefaultPlayback();
           state.cinematicPlayed = false;
           state.animationPhase = 'idle';

--- a/app/src/store/defaults.ts
+++ b/app/src/store/defaults.ts
@@ -78,8 +78,6 @@ export function createDefaultVideoExportSettings(): VideoExportSettings {
     fps: 30,
     resolution: { width: 1920, height: 1080 },
     aspectRatio: '16:9',
-    includeStats: true,
-    includeElevation: false,
     includeAudio: false,
   };
 }

--- a/app/src/store/slices/landmarksSlice.ts
+++ b/app/src/store/slices/landmarksSlice.ts
@@ -1,0 +1,33 @@
+import type { LandmarkType } from '@/types/landmarks';
+import type { AppState } from '@/store/storeTypes';
+import type { AppSliceCreator } from './types';
+
+type LandmarksSlice = Pick<AppState,
+  'userLandmarks' | 'enabledLandmarkGroups' |
+  'showAutomaticLandmarks' |
+  'enrichedLandmarks' | 'nearbyPlacesEnabled' | 'nearbyPlacesLoading' | 'nearbyPlacesError' |
+  'addLandmark' | 'updateLandmark' | 'removeLandmark' | 'setEnabledLandmarkGroups' |
+  'setNearbyPlacesEnabled' | 'setEnrichedLandmarks' | 'setNearbyPlacesStatus' | 'setShowAutomaticLandmarks'>;
+
+export const createLandmarksSlice: AppSliceCreator<LandmarksSlice> = (set) => ({
+  userLandmarks: [],
+  showAutomaticLandmarks: false,
+  enabledLandmarkGroups: [],
+  enrichedLandmarks: [],
+  nearbyPlacesEnabled: false,
+  nearbyPlacesLoading: false,
+  nearbyPlacesError: null,
+  addLandmark: (landmark) => set((state) => { state.userLandmarks.push(landmark); }),
+  updateLandmark: (id, updates) => set((state) => {
+    const landmark = state.userLandmarks.find((entry) => entry.id === id);
+    if (landmark) Object.assign(landmark, updates);
+  }),
+  removeLandmark: (id) => set((state) => {
+    state.userLandmarks = state.userLandmarks.filter((entry) => entry.id !== id);
+  }),
+  setShowAutomaticLandmarks: (showAutomaticLandmarks) => set((state) => { state.showAutomaticLandmarks = showAutomaticLandmarks; }),
+  setEnabledLandmarkGroups: (groups: LandmarkType[]) => set((state) => { state.enabledLandmarkGroups = groups; }),
+  setNearbyPlacesEnabled: (enabled) => set((state) => { state.nearbyPlacesEnabled = enabled; if (!enabled) state.enrichedLandmarks = []; }),
+  setEnrichedLandmarks: (landmarks) => set((state) => { state.enrichedLandmarks = landmarks; }),
+  setNearbyPlacesStatus: (loading, error = null) => set((state) => { state.nearbyPlacesLoading = loading; state.nearbyPlacesError = error; }),
+});

--- a/app/src/store/storeTypes.ts
+++ b/app/src/store/storeTypes.ts
@@ -19,6 +19,7 @@ import type {
   TransportMode,
   TrailStyleSettings,
 } from '@/types';
+import type { LandmarkType, RouteLandmark } from '@/types/landmarks';
 
 export interface AppState {
   tracks: GPXTrack[];
@@ -31,6 +32,13 @@ export interface AppState {
   videos: VideoAnnotation[];
   iconChanges: IconChange[];
   textAnnotations: TextAnnotation[];
+  userLandmarks: RouteLandmark[];
+  enrichedLandmarks: RouteLandmark[];
+  showAutomaticLandmarks: boolean;
+  enabledLandmarkGroups: LandmarkType[];
+  nearbyPlacesEnabled: boolean;
+  nearbyPlacesLoading: boolean;
+  nearbyPlacesError: string | null;
   playback: PlaybackState;
   cinematicPlayed: boolean;
   animationPhase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended';
@@ -87,6 +95,14 @@ export interface AppState {
   addTextAnnotation: (annotation: TextAnnotation) => void;
   updateTextAnnotation: (annotationId: string, updates: Partial<TextAnnotation>) => void;
   removeTextAnnotation: (annotationId: string) => void;
+  addLandmark: (landmark: RouteLandmark) => void;
+  updateLandmark: (landmarkId: string, updates: Partial<RouteLandmark>) => void;
+  removeLandmark: (landmarkId: string) => void;
+  setShowAutomaticLandmarks: (show: boolean) => void;
+  setEnabledLandmarkGroups: (groups: LandmarkType[]) => void;
+  setNearbyPlacesEnabled: (enabled: boolean) => void;
+  setEnrichedLandmarks: (landmarks: RouteLandmark[]) => void;
+  setNearbyPlacesStatus: (loading: boolean, error?: string | null) => void;
   setPlayback: (playback: Partial<PlaybackState>) => void;
   play: () => void;
   pause: () => void;

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -186,8 +186,6 @@ export interface VideoExportSettings {
   fps: number;
   resolution: { width: number; height: number };
   aspectRatio: AspectRatio;
-  includeStats: boolean;
-  includeElevation: boolean;
   includeAudio: boolean;
 }
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -134,6 +134,8 @@ export interface TextAnnotation {
   displayDuration: number;
 }
 
+export * from './landmarks';
+
 export interface PlaybackState {
   isPlaying: boolean;
   currentTime: number;

--- a/app/src/types/landmarks.ts
+++ b/app/src/types/landmarks.ts
@@ -1,0 +1,30 @@
+export type LandmarkType =
+  | 'summit' | 'pass' | 'viewpoint' | 'high-point' | 'waterfall'
+  | 'trailhead' | 'hut' | 'shelter' | 'camp' | 'water' | 'aid-station'
+  | 'finish' | 'town' | 'lake' | 'river-crossing'
+  | 'photo' | 'note' | 'challenge' | 'custom'
+  | 'highest-point' | 'longest-climb' | 'major-descent' | 'halfway';
+
+export type LandmarkSource = 'automatic' | 'user' | 'enriched' | 'media';
+export type LandmarkDisplay = 'subtle' | 'highlight';
+
+export interface RouteLandmark {
+  id: string;
+  type: LandmarkType;
+  source: LandmarkSource;
+  display: LandmarkDisplay;
+  lat: number;
+  lon: number;
+  progress: number | null;
+  elevation?: number;
+  title: string;
+  subtitle?: string;
+  importance: 1 | 2 | 3 | 4 | 5;
+  routeDistanceMeters?: number;
+  color?: string;
+  metadata?: {
+    osmId?: string;
+    tags?: Record<string, string>;
+    generatedKind?: 'local-maximum' | 'longest-climb' | 'major-descent' | 'halfway';
+  };
+}

--- a/app/src/utils/landmarkVisibility.test.ts
+++ b/app/src/utils/landmarkVisibility.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { selectVisibleLandmarks } from './landmarkVisibility';
+import type { RouteLandmark } from '@/types/landmarks';
+
+const landmarks: RouteLandmark[] = Array.from({ length: 8 }, (_, index) => ({ id: String(index), type: 'custom', source: 'automatic', display: 'subtle', lat: 45, lon: 6, progress: index / 8, title: String(index), importance: 5 - Math.min(index, 4) as 1 | 2 | 3 | 4 | 5, routeDistanceMeters: index * 100 }));
+
+describe('selectVisibleLandmarks', () => {
+  it('caps very-close icon candidates at six', () => {
+    expect(selectVisibleLandmarks(landmarks, { mode: 'follow-behind', preset: 'very-close', progress: 0, totalDistanceMeters: 1_000 }).length).toBe(6);
+  });
+});

--- a/app/src/utils/landmarkVisibility.ts
+++ b/app/src/utils/landmarkVisibility.ts
@@ -1,0 +1,17 @@
+import type { RouteLandmark } from '@/types/landmarks';
+
+export interface LandmarkVisibilityInput {
+  mode: 'overview' | 'follow' | 'follow-behind';
+  preset?: 'very-close' | 'close' | 'medium' | 'far';
+  progress: number;
+  totalDistanceMeters: number;
+}
+
+export function selectVisibleLandmarks(landmarks: RouteLandmark[], input: LandmarkVisibilityInput): RouteLandmark[] {
+  const ranked = [...landmarks].sort((a, b) => b.importance - a.importance);
+  if (input.mode === 'overview') return ranked.filter((landmark) => landmark.importance >= 4).concat(ranked.filter((landmark) => landmark.importance < 4).slice(0, 8));
+  const radius = input.preset === 'very-close' ? 1_500 : 5_000;
+  const aroundMarker = ranked.filter((landmark) => Math.abs((landmark.routeDistanceMeters ?? 0) - input.progress * input.totalDistanceMeters) <= radius);
+  if (input.preset === 'very-close') return aroundMarker.slice(0, 6);
+  return aroundMarker.slice(0, 16);
+}

--- a/app/src/utils/replayCameraPlan.test.ts
+++ b/app/src/utils/replayCameraPlan.test.ts
@@ -39,6 +39,28 @@ describe('replay camera plan', () => {
     expect(getRouteBearingAtProgress(coordinates, 0)).toBeCloseTo(90, 5);
   });
 
+  it('widens the close camera progressively as a route climbs', () => {
+    const elevationData = [
+      { elevation: 600 },
+      { elevation: 1800 },
+      { elevation: 2400 },
+    ];
+
+    expect(getPlaybackCameraPose({
+      ...options,
+      cameraMode: 'follow-behind',
+      elevationData,
+      progress: 0,
+    })).toMatchObject({ zoom: 16, pitch: 55 });
+
+    expect(getPlaybackCameraPose({
+      ...options,
+      cameraMode: 'follow-behind',
+      elevationData,
+      progress: 1,
+    })).toMatchObject({ zoom: 14, pitch: 40 });
+  });
+
   it('adds an incoming-bearing warmup pose around a turn', () => {
     const poses = getPredictivePlaybackPoses({
       currentProgress: 0,

--- a/app/src/utils/replayCameraPlan.test.ts
+++ b/app/src/utils/replayCameraPlan.test.ts
@@ -23,6 +23,9 @@ describe('replay camera plan', () => {
     expect(getPlaybackCameraPose({ ...options, cameraMode: 'follow-behind' })).toMatchObject({
       center: [0, 0], zoom: 16, pitch: 55, bearing: 90,
     });
+    expect(getIntroCameraPose({ ...options, cameraMode: 'follow-behind' })).toMatchObject({
+      center: [0, 0], zoom: 16, pitch: 55, bearing: 90,
+    });
     expect(getPlaybackCameraPose({ ...options, cameraMode: 'overview' })).toBeNull();
   });
 

--- a/app/src/utils/replayCameraPlan.ts
+++ b/app/src/utils/replayCameraPlan.ts
@@ -105,10 +105,24 @@ export function getPlaybackCameraPose(options: CameraPlanOptions): ReplayCameraP
   }
 
   const preset = getFollowBehindCameraTarget(options.followBehindZoomLevel, 'playback');
+  const elevationIndex = Math.round(clamp(options.progress, 0, 1) * Math.max(0, options.elevationData.length - 1));
+  const elevation = options.elevationData[elevationIndex]?.elevation ?? 0;
+  const { zoomAdjust, pitchAdjust } = calculateTerrainAwareAdjustments(
+    elevation,
+    options.elevationData,
+    options.progress,
+  );
   return {
     center,
-    zoom: preset.zoom,
-    pitch: preset.pitch,
+    // The old code applied terrain protection only to the intro fly-in, then
+    // restored the close preset for every playback frame. On long climbs that
+    // made the marker leave the close, pitched viewport. Keep this correction
+    // active for the full replay so the camera opens as elevation increases.
+    // Do not cap to the intro's conservative maximums here: at low altitude a
+    // user-selected close preset must remain genuinely close. The adjustments
+    // only ever widen/flatten the view and cannot overshoot the safe minima.
+    zoom: Math.max(TERRAIN_CAMERA_SETTINGS.MIN_ZOOM, preset.zoom - zoomAdjust),
+    pitch: Math.max(TERRAIN_CAMERA_SETTINGS.MIN_PITCH, preset.pitch - pitchAdjust),
     bearing: getRouteBearingAtProgress(options.coordinates, options.progress),
   };
 }

--- a/app/src/utils/replayCameraPlan.ts
+++ b/app/src/utils/replayCameraPlan.ts
@@ -70,7 +70,10 @@ export function getIntroCameraPose(options: CameraPlanOptions): ReplayCameraPose
     return { center, zoom: FOLLOW_CAMERA_ZOOM, pitch: 0, bearing: 0 };
   }
 
-  const preset = getFollowBehindCameraTarget(options.followBehindZoomLevel, 'intro');
+  // The fly-in must finish on the same pose used by the first playback frame.
+  // A separate, more distant intro target created a visible second zoom after
+  // the fly-in before the marker could begin moving along the route.
+  const preset = getFollowBehindCameraTarget(options.followBehindZoomLevel, 'playback');
   const elevationIndex = Math.round(clamp(options.progress, 0, 1) * Math.max(0, options.elevationData.length - 1));
   const elevation = options.elevationData[elevationIndex]?.elevation ?? 0;
   const { zoomAdjust, pitchAdjust } = calculateTerrainAwareAdjustments(
@@ -81,16 +84,8 @@ export function getIntroCameraPose(options: CameraPlanOptions): ReplayCameraPose
 
   return {
     center,
-    zoom: clamp(
-      preset.zoom - zoomAdjust,
-      TERRAIN_CAMERA_SETTINGS.MIN_ZOOM,
-      TERRAIN_CAMERA_SETTINGS.MAX_ZOOM,
-    ),
-    pitch: clamp(
-      preset.pitch - pitchAdjust,
-      TERRAIN_CAMERA_SETTINGS.MIN_PITCH,
-      TERRAIN_CAMERA_SETTINGS.MAX_PITCH,
-    ),
+    zoom: Math.max(TERRAIN_CAMERA_SETTINGS.MIN_ZOOM, preset.zoom - zoomAdjust),
+    pitch: Math.max(TERRAIN_CAMERA_SETTINGS.MIN_PITCH, preset.pitch - pitchAdjust),
     bearing: getRouteBearingAtProgress(options.coordinates, options.progress),
   };
 }

--- a/app/src/utils/resolveRouteLandmarks.test.ts
+++ b/app/src/utils/resolveRouteLandmarks.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRouteLandmarks } from './resolveRouteLandmarks';
+import type { RouteLandmark } from '@/types/landmarks';
+
+const landmark = (id: string, source: RouteLandmark['source'], distance: number, importance: RouteLandmark['importance'] = 3): RouteLandmark => ({ id, type: 'custom', source, display: 'subtle', lat: 45, lon: 6 + distance / 100_000, progress: 0, title: id, importance, routeDistanceMeters: distance });
+
+describe('resolveRouteLandmarks', () => {
+  it('prefers a user landmark when candidates share an anchor', () => {
+    expect(resolveRouteLandmarks([landmark('automatic', 'automatic', 100), landmark('user', 'user', 110)]).map((entry) => entry.id)).toEqual(['user']);
+  });
+
+  it('caps lower-priority labels in the same route corridor', () => {
+    expect(resolveRouteLandmarks([landmark('first', 'automatic', 100), landmark('second', 'automatic', 200)]).length).toBe(1);
+  });
+});

--- a/app/src/utils/resolveRouteLandmarks.ts
+++ b/app/src/utils/resolveRouteLandmarks.ts
@@ -1,0 +1,22 @@
+import type { RouteLandmark } from '@/types/landmarks';
+import { calculateDistance } from '@/utils/journeyUtils';
+
+const SOURCE_WEIGHT = { user: 4, media: 3, enriched: 2, automatic: 1 } as const;
+
+function score(landmark: RouteLandmark, activeId?: string | null) {
+  return (landmark.id === activeId ? 10_000 : 0) + landmark.importance * 100 + SOURCE_WEIGHT[landmark.source] * 10 + (landmark.type === 'finish' ? 45 : 0) + (landmark.type === 'highest-point' ? 35 : 0);
+}
+
+export function resolveRouteLandmarks(landmarks: RouteLandmark[], activeId?: string | null): RouteLandmark[] {
+  const sorted = [...landmarks].sort((a, b) => score(b, activeId) - score(a, activeId));
+  const selected: RouteLandmark[] = [];
+  for (const landmark of sorted) {
+    const duplicate = selected.find((entry) => calculateDistance(entry.lat, entry.lon, landmark.lat, landmark.lon) * 1000 < 80);
+    if (duplicate) continue;
+    const corridorConflict = landmark.importance < 5 && selected.find((entry) => Math.abs((entry.routeDistanceMeters ?? -Infinity) - (landmark.routeDistanceMeters ?? Infinity)) < 250);
+    if (corridorConflict) continue;
+    selected.push(landmark);
+    if (selected.length === 40) break;
+  }
+  return selected.sort((a, b) => (a.routeDistanceMeters ?? 0) - (b.routeDistanceMeters ?? 0));
+}

--- a/app/src/utils/routeLandmarks.test.ts
+++ b/app/src/utils/routeLandmarks.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeRouteLandmarks } from './routeLandmarks';
+
+const route = (elevations: number[], spacing = 1_000) => elevations.map((elevation, index) => ({ lat: 45 + index * 0.009, lon: 6, elevation, distance: index * spacing }));
+
+describe('analyzeRouteLandmarks', () => {
+  it('keeps the absolute high point despite noisy elevation samples', () => {
+    const landmarks = analyzeRouteLandmarks(route([900, 940, 930, 1_020, 1_000, 1_210, 1_180, 1_150]));
+    expect(landmarks.find((landmark) => landmark.type === 'highest-point')?.elevation).toBeGreaterThan(1_100);
+  });
+
+  it('does not invent terrain moments for a flat route', () => {
+    const landmarks = analyzeRouteLandmarks(route([100, 101, 99, 100, 101, 100]));
+    expect(landmarks.map((landmark) => landmark.type)).toEqual(['halfway', 'finish']);
+  });
+
+  it('adds sustained climb and descent moments', () => {
+    const landmarks = analyzeRouteLandmarks(route([800, 850, 980, 1_140, 1_300, 1_180, 980, 780]));
+    expect(landmarks.some((landmark) => landmark.type === 'longest-climb')).toBe(true);
+    expect(landmarks.some((landmark) => landmark.type === 'major-descent')).toBe(true);
+  });
+});

--- a/app/src/utils/routeLandmarks.ts
+++ b/app/src/utils/routeLandmarks.ts
@@ -1,0 +1,78 @@
+import type { RouteLandmark } from '@/types/landmarks';
+import { calculateDistance } from '@/utils/journeyUtils';
+
+export interface RouteElevationPoint { lat: number; lon: number; elevation?: number; distance?: number; progress?: number }
+interface ProfilePoint extends Required<Pick<RouteElevationPoint, 'lat' | 'lon'>> { elevation: number; distance: number; progress: number; smoothedElevation: number }
+
+const MIN_ROUTE_DISTANCE = 5_000;
+const PEAK_PROMINENCE = 100;
+const PEAK_SPACING = 1_500;
+
+function validElevation(value: number | undefined): value is number { return Number.isFinite(value) && value !== 0; }
+function elevationLabel(elevation: number) { return `${Math.round(elevation).toLocaleString()} m`; }
+
+export function buildRouteElevationProfile(points: RouteElevationPoint[]): ProfilePoint[] {
+  if (points.length < 2) return [];
+  let distance = 0;
+  const raw = points.map((point, index) => {
+    if (index > 0) distance += point.distance !== undefined
+      ? Math.max(0, point.distance - (points[index - 1].distance ?? 0))
+      : calculateDistance(points[index - 1].lat, points[index - 1].lon, point.lat, point.lon) * 1000;
+    return { ...point, distance, progress: point.progress ?? 0, elevation: point.elevation ?? Number.NaN };
+  });
+  const totalDistance = raw.at(-1)?.distance ?? 0;
+  return raw.map((point, index) => {
+    const windowStart = point.distance - 120;
+    const windowEnd = point.distance + 120;
+    const nearby = raw.filter((candidate) => candidate.distance >= windowStart && candidate.distance <= windowEnd && validElevation(candidate.elevation));
+    return {
+      lat: point.lat, lon: point.lon, elevation: point.elevation, distance: point.distance,
+      progress: point.progress || (totalDistance ? point.distance / totalDistance : index / (raw.length - 1)),
+      smoothedElevation: nearby.length ? nearby.reduce((sum, candidate) => sum + candidate.elevation, 0) / nearby.length : Number.NaN,
+    };
+  });
+}
+
+function landmark(id: string, type: RouteLandmark['type'], point: ProfilePoint, title: string, subtitle: string | undefined, importance: RouteLandmark['importance'], generatedKind?: NonNullable<RouteLandmark['metadata']>['generatedKind']): RouteLandmark {
+  return { id, type, source: 'automatic', display: 'subtle', lat: point.lat, lon: point.lon, progress: point.progress, elevation: point.elevation, title, subtitle, importance, routeDistanceMeters: point.distance, metadata: generatedKind ? { generatedKind } : undefined };
+}
+
+export function analyzeRouteLandmarks(points: RouteElevationPoint[]): RouteLandmark[] {
+  const profile = buildRouteElevationProfile(points);
+  if (profile.length < 2) return [];
+  const totalDistance = profile.at(-1)?.distance ?? 0;
+  const result: RouteLandmark[] = [];
+  const elevated = profile.filter((point) => validElevation(point.smoothedElevation));
+  const range = elevated.length ? Math.max(...elevated.map((point) => point.smoothedElevation)) - Math.min(...elevated.map((point) => point.smoothedElevation)) : 0;
+  if (elevated.length && range >= 30) {
+    const high = elevated.reduce((best, point) => point.smoothedElevation > best.smoothedElevation ? point : best);
+    result.push(landmark('automatic-highest-point', 'highest-point', high, 'Highest point', elevationLabel(high.smoothedElevation), 5, 'local-maximum'));
+    const localPeaks = elevated.filter((point, index) => {
+      const around = elevated.filter((candidate) => Math.abs(candidate.distance - point.distance) <= 750);
+      return index > 0 && index < elevated.length - 1 && point.smoothedElevation === Math.max(...around.map((candidate) => candidate.smoothedElevation)) && high.smoothedElevation - Math.min(...around.map((candidate) => candidate.smoothedElevation)) >= PEAK_PROMINENCE;
+    });
+    for (const peak of localPeaks.sort((a, b) => b.smoothedElevation - a.smoothedElevation)) {
+      if (result.filter((entry) => entry.type === 'high-point' || entry.type === 'highest-point').some((entry) => Math.abs((entry.routeDistanceMeters ?? 0) - peak.distance) < PEAK_SPACING)) continue;
+      if (result.filter((entry) => entry.type === 'high-point').length >= 3) break;
+      result.push(landmark(`automatic-peak-${Math.round(peak.distance)}`, 'high-point', peak, 'High point', elevationLabel(peak.smoothedElevation), 3, 'local-maximum'));
+    }
+    let bestClimb: { start: ProfilePoint; end: ProfilePoint; gain: number } | null = null;
+    let bestDescent: { start: ProfilePoint; end: ProfilePoint; loss: number } | null = null;
+    for (let startIndex = 0; startIndex < elevated.length; startIndex++) for (let endIndex = startIndex + 1; endIndex < elevated.length; endIndex++) {
+      const start = elevated[startIndex]; const end = elevated[endIndex]; const length = end.distance - start.distance;
+      if (length < 500 || length > 12_000) continue;
+      const change = end.smoothedElevation - start.smoothedElevation;
+      if (change >= 120 && change / length >= 0.04 && (!bestClimb || change > bestClimb.gain)) bestClimb = { start, end, gain: change };
+      if (change <= -120 && -change / length >= 0.04 && (!bestDescent || -change > bestDescent.loss)) bestDescent = { start, end, loss: -change };
+    }
+    if (bestClimb) result.push(landmark('automatic-longest-climb', 'longest-climb', bestClimb.end, 'Longest climb', `+${Math.round(bestClimb.gain)} m`, 4, 'longest-climb'));
+    if (bestDescent) result.push(landmark('automatic-major-descent', 'major-descent', bestDescent.end, 'Major descent', `−${Math.round(bestDescent.loss)} m`, 3, 'major-descent'));
+  }
+  if (totalDistance >= MIN_ROUTE_DISTANCE) {
+    const halfway = profile.reduce((best, point) => Math.abs(point.distance - totalDistance / 2) < Math.abs(best.distance - totalDistance / 2) ? point : best);
+    result.push(landmark('automatic-halfway', 'halfway', halfway, 'Halfway', undefined, 3, 'halfway'));
+  }
+  const finish = profile.at(-1)!;
+  result.push(landmark('automatic-finish', 'finish', finish, 'Finish', undefined, 4));
+  return result;
+}

--- a/docs/internal/route-landmarks-implementation-plan.md
+++ b/docs/internal/route-landmarks-implementation-plan.md
@@ -1,0 +1,247 @@
+# Route Landmarks Implementation Plan
+
+## Goal
+
+Make replays feel aware of their landscape without covering the map in UI. The
+system should support summits, passes, huts, lakes, waterfalls, trailheads,
+towns, route milestones, media and user-created story moments.
+
+Landmarks are quiet, terrain-integrated symbols by default. The route marker is
+always dominant; an annotation card appears only for an active user highlight.
+
+## Current State
+
+- `useTextAnnotationsLayer.ts` renders authored annotation dots and a large
+  active canvas card. It is a playback-story UI, not a subtle landscape layer.
+- `RouteAnnotationsEditor.tsx` creates authored points at the current replay
+  position.
+- MapLibre already renders the route on a DEM-backed 3D terrain scene.
+
+Use native MapLibre GeoJSON/circle/symbol layers for v1. They give collision
+handling, zoom expressions and map-pitch alignment. Do not use DOM markers for
+landmarks. Literal 3D mesh objects need a custom WebGL/Three.js layer and are a
+future enhancement, not a requirement for terrain-feeling labels.
+
+## Data Model
+
+Create `app/src/types/landmarks.ts`.
+
+```ts
+export type LandmarkType =
+  | 'summit' | 'pass' | 'viewpoint' | 'high-point' | 'waterfall'
+  | 'trailhead' | 'hut' | 'shelter' | 'camp' | 'water' | 'aid-station'
+  | 'finish' | 'town' | 'lake' | 'river-crossing'
+  | 'photo' | 'note' | 'challenge' | 'custom'
+  | 'highest-point' | 'longest-climb' | 'major-descent' | 'halfway';
+
+export type LandmarkSource = 'automatic' | 'user' | 'enriched' | 'media';
+export type LandmarkDisplay = 'subtle' | 'highlight';
+
+export interface RouteLandmark {
+  id: string;
+  type: LandmarkType;
+  source: LandmarkSource;
+  display: LandmarkDisplay;
+  lat: number;
+  lon: number;
+  progress: number | null;
+  elevation?: number;
+  title: string;
+  subtitle?: string;
+  importance: 1 | 2 | 3 | 4 | 5;
+  routeDistanceMeters?: number;
+  metadata?: {
+    osmId?: string;
+    tags?: Record<string, string>;
+    generatedKind?: 'local-maximum' | 'longest-climb' | 'major-descent' | 'halfway';
+  };
+}
+```
+
+Persist user landmarks only. Automatic landmarks are recomputed from the route;
+enriched results are disposable cache entries. Keep `TextAnnotation` separate;
+add an optional `landmarkId` link later when a user wants a card and a subtle
+terrain anchor at the same location.
+
+Create `landmarksSlice.ts` and wire it through `storeTypes.ts` and
+`createAppStore.ts`:
+
+- `userLandmarks`, `showLandmarks`, `enabledLandmarkGroups`
+- add, update, remove, and filter-setting actions
+
+## Architecture
+
+```mermaid
+flowchart LR
+  R["GPX / computed journey"] --> A["Automatic route analysis"]
+  U["User highlights"] --> X["Landmark resolver"]
+  E["Optional named-place enrichment"] --> X
+  A --> X
+  X --> V["Camera-corridor filter"]
+  V --> M["MapLibre landmark layers"]
+  X --> C["Active playback card"]
+```
+
+The resolver deduplicates all inputs. The map layer receives only the selected
+visible subset, and updates its source only when that subset changes.
+
+## Phase 1: Automatic Route Moments
+
+Create `app/src/utils/routeLandmarks.ts` with pure functions:
+
+1. Build a distance/progress/elevation profile from `ComputedJourney` or the
+   active GPX track.
+2. Smooth elevation over physical distance (not GPX-point count) to avoid false
+   peaks from GPS altitude noise.
+3. Detect local high points using a minimum 100 m prominence, 1.5 km spacing,
+   and a four-label cap. Always include the absolute high point.
+4. Detect one meaningful sustained climb and one major descent with gain/grade
+   thresholds.
+5. Add route-independent milestones: halfway for routes >=5 km and finish.
+
+Automatic titles are localized, concise, and data-led: `Highest point`,
+`2,379 m`; `Longest climb`, `+820 m`; `Halfway`.
+
+Return no terrain features when elevations are missing or flat. Do not invent
+summits from a route line alone.
+
+Create `app/src/utils/resolveRouteLandmarks.ts`:
+
+- merge features within 80 m;
+- user landmarks beat automatic, media and enriched metadata;
+- cap to one label per 250 m corridor section unless importance is 5;
+- priority: active user highlight > finish > selected landmark > highest point
+  > named summit/pass > contextual POI.
+
+Create `app/src/hooks/useRouteLandmarks.ts` to memoize analysis, merge user
+landmarks, and supply a stable resolved list to `TrailMap.tsx`.
+
+## Phase 2: Terrain Landmark Layer
+
+Create `app/src/components/map/hooks/useRouteLandmarksLayer.ts`.
+
+Use one GeoJSON source and three layers:
+
+1. `route-landmarks-halo`: tiny low-opacity, map-pitch-aligned circle anchoring
+   the point to terrain.
+2. `route-landmarks-icon`: generated monochrome SVG/SDF icon (14-18 px),
+   map-pitch and map-rotation aligned. SDF allows data-driven colors.
+3. `route-landmarks-label`: 10-11 px text, viewport-aligned for readability,
+   with a dark 1 px halo and `text-optional: true`.
+
+Rendering rules:
+
+- use `symbol-sort-key` from importance and normal collision handling;
+- contextual POIs: muted sand/grey at 55-70% opacity;
+- terrain features: alpine blue-grey at 70-85% opacity;
+- user highlights: their chosen color; active highlight gets the strongest
+  anchor plus the existing card, not a permanent oversized map label;
+- fade labels below zoom 11; render icon-only when labels collide;
+- maximum label text: title plus elevation on a second line for terrain types;
+- never use emoji in the map symbol layer.
+
+Create `app/src/utils/landmarkVisibility.ts` to select the visible subset:
+
+- Overview: all importance 4-5 features plus a capped selection of lower ones.
+- Follow Behind: candidates within roughly 1.5 screen widths around/ahead of
+  the marker.
+- Very Close: maximum three labels and six icons; keep landmarks for a 2-second
+  hysteresis window to prevent popping during turns.
+- Export: filtering depends only on replay progress, never wall-clock time.
+
+## Phase 3: User Highlights and Media
+
+Create `RouteLandmarksEditor.tsx` in the existing annotation/media panel.
+
+- Add a marker at current replay position.
+- Select type, title, subtitle, and color for custom story types.
+- Show generated route moments read-only in a separate section.
+- Selecting a landmark seeks to it and temporarily promotes it to the active
+  annotation-card flow.
+- Let existing text annotations opt into “Also show as terrain landmark” rather
+  than silently migrating every card.
+
+Pictures/videos with route coordinates derive low-priority `photo` landmarks
+when media visibility is enabled, without replacing their current interaction.
+
+Add project persistence/import-export support for user landmarks and ensure
+video capture waits for the landmark source/layers to be initialized.
+
+## Phase 4: Optional Named-Place Enrichment
+
+This must be explicit opt-in. It is valuable for named peaks, passes, huts,
+waterfalls, viewpoints, lakes, trailheads and towns, but must not send every
+route to a third party by default.
+
+Add a Cloudflare Pages Function:
+
+- `functions/api/landmarks.js`
+
+Client behavior:
+
+- user enables “Nearby places and landmarks”;
+- client sends a simplified, bounded route corridor, not raw GPX;
+- results become `source: 'enriched'` landmarks and flow through the same
+  resolver and layer.
+
+Function behavior:
+
+- validate corridor area, route length and payload size;
+- query/cache OpenStreetMap-derived features for peaks, passes, huts, shelters,
+  viewpoints, waterfalls, water, places and trailheads;
+- normalize tags to `LandmarkType`;
+- cache using rounded corridor tiles and implementation version;
+- cap raw results at 100 and selected results at 24;
+- include required OSM attribution data;
+- never run during playback/export frames.
+
+Create `landmarkCorridor.ts` to simplify the path, project returned POIs to the
+route via `routeProjection.ts`, reject distant POIs, and rank results by type,
+name, route distance and importance. Allow users to hide a suggested place and
+persist dismissals by OSM id.
+
+## Tests
+
+- `routeLandmarks.test.ts`: noisy altitude, absolute high point, peak spacing,
+  flat/missing elevation, climb/descent thresholds.
+- `resolveRouteLandmarks.test.ts`: merge distance and source/importance rules.
+- `landmarkVisibility.test.ts`: close-camera caps, ranking, hysteresis inputs.
+- `landmarkCorridor.test.ts`: simplification, route projection and POI ranking.
+- function tests: input validation, response caps and cache-key behavior.
+- MapLibre hook tests with mocked map APIs for source/layer creation and cleanup.
+
+## Performance Budget
+
+| Metric | Target |
+| --- | --- |
+| Resolved landmarks per route | <= 40 |
+| Visible icons in close replay | <= 6 |
+| Visible labels in close replay | <= 3 |
+| New MapLibre layers | 3 + one GeoJSON source |
+| Per-frame allocations | none |
+| Enrichment calls by default | 0 |
+
+Profile the feature using the UTMB GPX at Follow Behind -> Very Close, 3D terrain
+enabled, at 4x and 8x. Compare frame time and tile diagnostics with landmarks
+off/on. Lower visible-label caps before adding richer visuals if replay smoothness
+changes.
+
+## Future Physical 3D Objects
+
+Only after the symbol-layer version succeeds: a custom MapLibre WebGL/Three.js
+layer may show up to three local low-poly objects (for example, a summit flag or
+hut silhouette) placed at terrain elevation. It must have no playback-time
+network fetches, be feature-flagged, and fall back to the normal symbol layer.
+
+## Rollout and Acceptance Criteria
+
+1. Ship types, automatic analysis, resolver, tests.
+2. Ship the subtle layer behind a local feature flag; validate UTMB performance.
+3. Add editor, annotation/media links, persistence and export verification.
+4. Enable automatic/user landmarks by default with a View-panel toggle.
+5. Add the opt-in cached named-place enrichment service.
+
+The release is ready when a mountain GPX shows only a handful of meaningful
+terrain moments; a flat GPX remains uncluttered; the marker remains dominant in
+Very Close; user highlights can be created/edited/hidden; no POI request occurs
+without consent; and the UTMB replay remains at baseline camera/tile quality.

--- a/functions/api/landmarks.js
+++ b/functions/api/landmarks.js
@@ -1,0 +1,78 @@
+const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+const MAX_POINTS = 180;
+const MAX_SPAN_DEGREES = 1.5;
+const CACHE_SECONDS = 60 * 60 * 24;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+const MAX_REQUESTS_PER_WINDOW = 12;
+const requestCounts = new Map();
+
+function json(body, status = 200, headers = {}) {
+  return Response.json(body, { status, headers: { 'Cache-Control': `public, max-age=${CACHE_SECONDS}`, ...headers } });
+}
+
+function normalizeElement(element) {
+  const tags = element.tags || {};
+  const lat = element.lat ?? element.center?.lat;
+  const lon = element.lon ?? element.center?.lon;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon) || !tags.name) return null;
+  const type = tags.natural === 'peak' ? 'summit'
+    : tags.natural === 'saddle' || tags.mountain_pass ? 'pass'
+      : tags.tourism === 'viewpoint' ? 'viewpoint'
+        : tags.tourism === 'alpine_hut' ? 'hut'
+          : tags.amenity === 'shelter' ? 'shelter'
+            : tags.natural === 'waterfall' ? 'waterfall'
+              : tags.natural === 'water' || tags.water === 'lake' ? 'lake'
+                : tags.place ? 'town' : null;
+  if (!type) return null;
+  const importance = type === 'summit' || type === 'pass' || type === 'town' ? 4 : 3;
+  return { id: `osm-${element.type}-${element.id}`, type, source: 'enriched', display: 'subtle', lat, lon, title: tags.name, subtitle: tags.ele ? `${tags.ele} m` : undefined, importance, metadata: { osmId: `${element.type}/${element.id}`, tags } };
+}
+
+function queryFor(bounds) {
+  const [south, west, north, east] = bounds;
+  const filters = [
+    'nwr["natural"="peak"]["name"]', 'nwr["natural"="saddle"]["name"]',
+    'nwr["tourism"="viewpoint"]["name"]', 'nwr["tourism"="alpine_hut"]["name"]',
+    'nwr["natural"="waterfall"]["name"]', 'nwr["water"="lake"]["name"]',
+    'nwr["place"~"^(city|town|village|hamlet)$"]["name"]',
+  ].map((filter) => `${filter}(${south},${west},${north},${east});`).join('');
+  return `[out:json][timeout:8];(${filters});out center tags;`;
+}
+
+function isRateLimited(request) {
+  const ip = (request.headers.get('cf-connecting-ip') || request.headers.get('x-forwarded-for') || 'unknown').split(',')[0].trim();
+  const now = Date.now();
+  const entry = requestCounts.get(ip);
+  if (!entry || now >= entry.resetAt) {
+    requestCounts.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > MAX_REQUESTS_PER_WINDOW;
+}
+
+export async function onRequestPost(context) {
+  if (isRateLimited(context.request)) return json({ error: 'Nearby-place lookup limit reached. Please try again later.' }, 429);
+  let body;
+  try { body = await context.request.json(); } catch { return json({ error: 'Invalid JSON body' }, 400); }
+  const points = body?.points;
+  if (!Array.isArray(points) || points.length < 2 || points.length > MAX_POINTS || !points.every((point) => Array.isArray(point) && point.length === 2 && point.every(Number.isFinite))) return json({ error: 'Expected 2–180 valid [longitude, latitude] points' }, 400);
+  const lons = points.map((point) => point[0]); const lats = points.map((point) => point[1]);
+  const bounds = [Math.min(...lats) - 0.015, Math.min(...lons) - 0.02, Math.max(...lats) + 0.015, Math.max(...lons) + 0.02];
+  if (bounds[2] - bounds[0] > MAX_SPAN_DEGREES || bounds[3] - bounds[1] > MAX_SPAN_DEGREES) return json({ error: 'Route corridor is too large for nearby-place lookup' }, 400);
+  const key = new Request(`${new URL(context.request.url).origin}/api/landmarks-cache/${points.map((point) => point.join(',')).join(';')}`);
+  const cached = await caches.default.match(key);
+  if (cached) return cached;
+  try {
+    const response = await fetch(OVERPASS_URL, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8', 'User-Agent': 'TrailReplay/1.0 (+https://trailreplay.app)' }, body: new URLSearchParams({ data: queryFor(bounds) }) });
+    if (!response.ok) return json({ error: 'Nearby-place service is temporarily unavailable' }, 502);
+    const payload = await response.json();
+    const landmarks = (payload.elements || []).map(normalizeElement).filter(Boolean).slice(0, 100);
+    const result = json({ landmarks, attribution: '© OpenStreetMap contributors' });
+    context.waitUntil(caches.default.put(key, result.clone()));
+    return result;
+  } catch (error) {
+    console.error('Landmark enrichment error', error);
+    return json({ error: 'Nearby-place service is temporarily unavailable' }, 502);
+  }
+}


### PR DESCRIPTION
## Summary
- add named route landmarks and improve annotation visibility
- smooth follow-camera turns and terrain-aware zoom adjustments
- make export honor Style overlays and capture the full intro/outro sequence
- refine the sidebar track cards and unify navigation icons
- make replay zoom controls reliably adjust the Follow Behind distance preset

## Verification
- npm --prefix app run lint
- npm --prefix app run test:run (102 passing)
- npm --prefix app run build

Local Wrangler runtime files are intentionally excluded.