### PR TITLE
Fix journey duration and picture replay behavior

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -78,6 +78,7 @@ function App() {
   const socialShareAspectRatio = useAppStore((state) => state.socialShareSettings.aspectRatio);
   const exportSubMode = useAppStore((state) => state.exportSubMode);
   const isExporting = useAppStore((state) => state.isExporting);
+  const isDeterministicExport = useAppStore((state) => state.isDeterministicExport);
 
   useEffect(() => {
     document.documentElement.lang = settings.language;
@@ -484,6 +485,7 @@ function App() {
                   picture={activePicture} 
                   onClose={closeActivePicture}
                   exportFrame={activeExportCropMetrics}
+                  playbackCurrentTime={isDeterministicExport ? playback.currentTime : undefined}
                 />
               )}
               

--- a/app/src/components/annotations/PicturePopup.tsx
+++ b/app/src/components/annotations/PicturePopup.tsx
@@ -11,9 +11,10 @@ interface PicturePopupProps {
   picture: PictureAnnotation;
   onClose?: () => void;
   exportFrame?: PicturePopupExportFrame | null;
+  playbackCurrentTime?: number;
 }
 
-export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProps) {
+export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTime }: PicturePopupProps) {
   const { t } = useI18n();
   const [animationState, setAnimationState] = useState<'entering' | 'visible' | 'exiting'>('entering');
   const [displayProgress, setDisplayProgress] = useState(0);
@@ -21,6 +22,7 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
   const progressIntervalRef = useRef<number | null>(null);
   const exitTimeoutRef = useRef<number | null>(null);
   const fallbackImageUrlRef = useRef<string | null>(null);
+  const playbackPopupStartTimeRef = useRef<number | null>(null);
   
   const displayDuration = picture.displayDuration || 5000;
   const { imageWidth, imageHeight, isExportSafe, popupStyle } = getPicturePopupLayout(exportFrame);
@@ -32,10 +34,15 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
     }
   }, []);
 
-  const startExit = useCallback(() => {
+  const startExit = useCallback((immediately = false) => {
     if (exitTimeoutRef.current !== null) return;
 
     clearProgressInterval();
+    if (immediately) {
+      onClose?.();
+      return;
+    }
+
     setAnimationState('exiting');
     exitTimeoutRef.current = window.setTimeout(() => {
       exitTimeoutRef.current = null;
@@ -44,6 +51,13 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
   }, [clearProgressInterval, onClose]);
 
   useEffect(() => {
+    // Deterministic exports advance the replay clock frame-by-frame rather than
+    // in wall-clock time. Show the popup immediately and let the effect below
+    // control its lifetime from that same clock.
+    if (playbackCurrentTime !== undefined) {
+      return;
+    }
+
     // After entering animation, show the picture
     const enterTimer = window.setTimeout(() => {
       setAnimationState('visible');
@@ -71,7 +85,23 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
         URL.revokeObjectURL(fallbackImageUrlRef.current);
       }
     };
-  }, [clearProgressInterval, displayDuration, startExit]);
+  }, [clearProgressInterval, displayDuration, playbackCurrentTime, startExit]);
+
+  useEffect(() => {
+    if (playbackCurrentTime === undefined) return;
+
+    if (playbackPopupStartTimeRef.current === null) {
+      playbackPopupStartTimeRef.current = playbackCurrentTime;
+    }
+
+    const elapsed = Math.max(0, playbackCurrentTime - playbackPopupStartTimeRef.current);
+    const progress = Math.min((elapsed / displayDuration) * 100, 100);
+    setDisplayProgress(progress);
+
+    if (progress >= 100) {
+      startExit(true);
+    }
+  }, [displayDuration, playbackCurrentTime, startExit]);
   
   const handleClose = () => {
     startExit();
@@ -79,7 +109,7 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
   
   // Animation classes based on state
   const getAnimationClasses = () => {
-    switch (animationState) {
+    switch (playbackCurrentTime === undefined ? animationState : 'visible') {
       case 'entering':
         return 'opacity-0 scale-90 translate-y-4';
       case 'visible':
@@ -114,7 +144,7 @@ export function PicturePopup({ picture, onClose, exportFrame }: PicturePopupProp
             <img
               src={imageSrc}
               alt={picture.title || t('media.trailPictureAlt')}
-              className="object-cover"
+              className="object-contain bg-[var(--evergreen)]/10"
               style={{ width: imageWidth, height: imageHeight }}
               onError={() => {
                 if (picture.displayFile && imageSrc === picture.url) {

--- a/app/src/components/sidebar/JourneyPanel.tsx
+++ b/app/src/components/sidebar/JourneyPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 
 const DEFAULT_TRACK_SEGMENT_DURATION_MS = 30_000;
+const MAX_SEGMENT_DURATION_SECONDS = 120;
 
 export function JourneyPanel() {
   const { t } = useI18n();
@@ -119,7 +120,8 @@ export function JourneyPanel() {
   };
   
   const updateSegmentDuration = (segmentId: string, duration: number) => {
-    updateJourneySegmentDuration(segmentId, duration * 1000);
+    const boundedDuration = Math.min(MAX_SEGMENT_DURATION_SECONDS, Math.max(1, duration));
+    updateJourneySegmentDuration(segmentId, boundedDuration * 1000);
     setEditingSegment(null);
   };
   
@@ -303,7 +305,7 @@ export function JourneyPanel() {
                     onRemove={() => removeJourneySegment(segment.id)}
                     onEditDuration={() => {
                       setEditingSegment(segment.id);
-                      setCustomDuration((segment.duration || 30000) / 1000);
+                      setCustomDuration(Math.min(MAX_SEGMENT_DURATION_SECONDS, (segment.duration || 30000) / 1000));
                     }}
                     onSeek={() => seekToProgress(getSegmentProgress(index))}
                   />
@@ -314,7 +316,7 @@ export function JourneyPanel() {
                     onRemove={() => removeJourneySegment(segment.id)}
                     onEditDuration={() => {
                       setEditingSegment(segment.id);
-                      setCustomDuration((segment.duration || 5000) / 1000);
+                      setCustomDuration(Math.min(MAX_SEGMENT_DURATION_SECONDS, (segment.duration || 5000) / 1000));
                     }}
                     onSeek={() => seekToProgress(getSegmentProgress(index))}
                   />
@@ -436,9 +438,13 @@ export function JourneyPanel() {
                   <input
                     type="number"
                     value={customDuration}
-                    onChange={(e) => setCustomDuration(Math.max(1, parseInt(e.target.value) || 1))}
+                    onChange={(e) => setCustomDuration(Math.min(
+                      MAX_SEGMENT_DURATION_SECONDS,
+                      Math.max(1, parseInt(e.target.value) || 1)
+                    ))}
                     className="flex-1 px-3 py-2 border-2 border-[var(--evergreen)]/30 rounded-lg bg-[var(--canvas)] text-[var(--evergreen)]"
                     min="1"
+                    max={MAX_SEGMENT_DURATION_SECONDS}
                     autoFocus
                   />
                   <span className="text-sm text-[var(--evergreen-60)]">{t('common.secondsShort')}</span>


### PR DESCRIPTION
Fixes #80
Fixes #81
Fixes #82

Summary:
- cap segment edits at the 120-second playback limit
- synchronize picture-popup timing with the deterministic export timeline
- preserve full portrait photos with contained rendering

@markhbish Thanks for taking the time to raise these issues — the detailed reports made them quick to address.